### PR TITLE
StorageContainerFileImpl.getNextHole may be inaccurate

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -71,7 +71,7 @@ unsigned long zfs_per_txg_dirty_frees_percent = 30;
 /*
  * Enable/disable forcing txg sync when dirty in dmu_offset_next.
  */
-int zfs_dmu_offset_next_sync = 0;
+int zfs_dmu_offset_next_sync = 1;
 
 /*
  * This can be used for testing, to ensure that certain actions happen


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->
On linux, SEEK_FILE / SEEK_HOLE are inaccurate if the file is dirty, in
which case they say that there are no holes.  To get the same behavior
as on illumos, we need to set zfs_dmu_offset_next_sync.

External-issue: LX-975
Signed-off-by: Matthew Ahrens <mahrens@delphix.com>


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-smoke/32627/consoleFull
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain `Signed-off-by`.
- [ ] Change has been approved by a ZFS on Linux member.
