### PR TITLE
LX-1103 Build ZFS packages with debuginfo

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -42,7 +42,8 @@ endif
 	  --with-udevdir=/lib/udev \
 	  --with-systemdunitdir=/lib/systemd/system \
 	  --with-systemdpresetdir=/lib/systemd/system-preset \
-	  --with-config=user
+	  --with-config=user \
+	  --enable-debuginfo
 
 override_dh_auto_test:
 	# The dh_auto_test rule is disabled because
@@ -158,7 +159,8 @@ override_dh_configure_modules_udeb_stamp:
 		--without-selinux \
 		--with-config=kernel \
 		--with-linux=$(KSRC) \
-		--with-linux-obj=$(KOBJ)
+		--with-linux-obj=$(KOBJ) \
+		--enable-debuginfo
 	touch override_dh_configure_modules_udeb_stamp
 
 override_dh_configure_modules: override_dh_configure_modules_stamp
@@ -166,7 +168,8 @@ override_dh_configure_modules_stamp:
 	./configure \
 		--with-config=kernel \
 		--with-linux=$(KSRC) \
-		--with-linux-obj=$(KOBJ)
+		--with-linux-obj=$(KOBJ) \
+		--enable-debuginfo
 	touch override_dh_configure_modules_stamp
 
 override_dh_binary-modules-udeb: override_dh_prep-deb-files override_dh_configure_modules_udeb


### PR DESCRIPTION
We need to configure the ZFS build with `--enable-debuginfo` in order to prevent some additional Linux optimizations (such as automatic inlining of functions) that are detrimental to debugging.

Note that this is different from `--enable-debug` which enables `-DDEBUG` and has a heavy impact on performance.

This change mirrors a similar change we did in git-zfs-make/load.

### How Has This Been Tested?
http://collins.d.delphix.com:32423/job/devops-gate/job/projects/job/dx4linux/job/zfs-package-build/job/master/job/pre-push/21/console
