### PR TITLE
LX-1118 Create a delphix-zfs meta-package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -185,3 +185,19 @@ Description: Debugging symbols for OpenZFS userland libraries and tools
  .
  This package contains the debugging symbols for libzpool2linux, libzfs2linux,
  libnvpair1linux, libuutil1linux, zfs-zed and zfsutils-linux.
+
+Package: delphix-zfs
+Section: misc
+Architecture: linux-any
+Depends: libnvpair1linux (= ${binary:Version}),
+         libuutil1linux (= ${binary:Version}),
+         libzfs2linux (= ${binary:Version}),
+         libzpool2linux (= ${binary:Version}),
+         libzfslinux-dev (= ${binary:Version}),
+         zfsutils-linux (= ${binary:Version}),
+         zfs-dbg (= ${binary:Version}),
+         zfs-initramfs (= ${binary:Version}),
+         zfs-test (= ${binary:Version}),
+         zfs-zed (= ${binary:Version}),
+         delphix-zfs-modules
+Description: Meta package for all ZFS packages installed on a Delphix appliance.

--- a/debian/control.in
+++ b/debian/control.in
@@ -185,3 +185,19 @@ Description: Debugging symbols for OpenZFS userland libraries and tools
  .
  This package contains the debugging symbols for libzpool2linux, libzfs2linux,
  libnvpair1linux, libuutil1linux, zfs-zed and zfsutils-linux.
+
+Package: delphix-zfs
+Section: misc
+Architecture: linux-any
+Depends: libnvpair1linux (= ${binary:Version}),
+         libuutil1linux (= ${binary:Version}),
+         libzfs2linux (= ${binary:Version}),
+         libzpool2linux (= ${binary:Version}),
+         libzfslinux-dev (= ${binary:Version}),
+         zfsutils-linux (= ${binary:Version}),
+         zfs-dbg (= ${binary:Version}),
+         zfs-initramfs (= ${binary:Version}),
+         zfs-test (= ${binary:Version}),
+         zfs-zed (= ${binary:Version}),
+         delphix-zfs-modules
+Description: Meta package for all ZFS packages installed on a Delphix appliance.

--- a/debian/control.modules.in
+++ b/debian/control.modules.in
@@ -17,7 +17,7 @@ Vcs-Browser: http://anonscm.debian.org/gitweb/?p=pkg-zfsonlinux/zfs.git
 
 Package: zfs-modules-_KVERS_
 Architecture: _ARCH_
-Provides: zfs-modules
+Provides: zfs-modules, delphix-zfs-modules
 Depends: linux-image-_KVERS_
 Recommends: zfsutils
 Description: OpenZFS filesystem kernel modules for Linux (kernel _KVERS_)


### PR DESCRIPTION
### Description
We want to create a "delphix-zfs" meta-package, so that it can be referenced in appliance-build to install all our zfs packages.

Note that currently we just install all the debs produced by the ZFS build job (with the debs with do not want to install deleted), but we are moving away from this logic. Instead we'll be adding our zfs packages to a seed repository which will be then passed to live-build.

I'm also adding a new virtual package: delphix-zfs-modules to make sure that delphix-zfs pulls delphix kernel modules.

### Notes
The changes must unfortunately be duplicated in both `control` and `control.in` because of how the packaging system is organized.

### Testing

http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/zfs-package-build/job/master/job/pre-push/4/console
I've tested that `delphix-zfs` can install correctly (all its dependences are satisfied), by installing all the debs from the job above on a `dlpx-linux-trunk` system.