### PR TITLE
Remove Ubuntu zfs kernel modules on install

### DIFF
--- a/debian/zfs-modules-_KVERS_.postinst.in
+++ b/debian/zfs-modules-_KVERS_.postinst.in
@@ -9,6 +9,15 @@ depmod -a _KVERS_
 
 case $1 in
 	(configure)
+		#
+		# Ubuntu kernel comes integrated with ZFS modules. We want to
+		# remove those.
+		#
+		find /lib/modules/_KVERS_/kernel/zfs \
+			-type f -name '*.ko' \
+			-exec dpkg-divert --local --rename {} \;
+			depmod -a _KVERS_
+
 		if [ -x /usr/share/update-notifier/notify-reboot-required ]; then
 			/usr/share/update-notifier/notify-reboot-required
 		fi

--- a/debian/zfs-modules-_KVERS_.triggers.in
+++ b/debian/zfs-modules-_KVERS_.triggers.in
@@ -1,0 +1,1 @@
+activate update-initramfs


### PR DESCRIPTION
Currently when we install our ZFS packages during appliance build we must also manually remove existing Ubuntu ZFS modules that come bundled with Ubuntu's kernel package (using dpkg-divert).
There are a few issues with this approach:
1. We cannot create an appliance just by installing a series of packages, we also need to run an external script.
2. We currently only do this for the initial installation. If we want to upgrade the kernel and install new ZFS modules we need to make sure we manually run that external script again.
3. Some steps such as updating initramfs can only be done when there is an initramfs installed, which is not the case at the earlier stages of live-build where the ZFS packages are installed.

A much cleaner way is to perform the additional steps as part of the package configuration phase.

### Testing
http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/zfs-package-build/job/master/job/pre-push/7/console (pass)
@prakashsurya Created a Delphix appliance with the ZFS packages and tested that it boots up.
