### PR TITLE
install ZFS modules into updates directory

### DIFF
--- a/debian/zfs-modules-_KVERS_.install.in
+++ b/debian/zfs-modules-_KVERS_.install.in
@@ -1,8 +1,8 @@
-module/zcommon/zcommon.ko	lib/modules/_KVERS_/extra/zcommon/
-module/zfs/zfs.ko		lib/modules/_KVERS_/extra/zfs/
-module/avl/zavl.ko		lib/modules/_KVERS_/extra/avl/
-module/unicode/zunicode.ko	lib/modules/_KVERS_/extra/unicode/
-module/nvpair/znvpair.ko	lib/modules/_KVERS_/extra/nvpair/
-module/icp/icp.ko		lib/modules/_KVERS_/extra/icp/
-module/lua/zlua.ko		lib/modules/_KVERS_/extra/lua/
-module/spl/spl.ko		lib/modules/_KVERS_/extra/spl/
+module/zcommon/zcommon.ko	lib/modules/_KVERS_/updates/zcommon/
+module/zfs/zfs.ko		lib/modules/_KVERS_/updates/zfs/
+module/avl/zavl.ko		lib/modules/_KVERS_/updates/avl/
+module/unicode/zunicode.ko	lib/modules/_KVERS_/updates/unicode/
+module/nvpair/znvpair.ko	lib/modules/_KVERS_/updates/nvpair/
+module/icp/icp.ko		lib/modules/_KVERS_/updates/icp/
+module/lua/zlua.ko		lib/modules/_KVERS_/updates/lua/
+module/spl/spl.ko		lib/modules/_KVERS_/updates/spl/

--- a/debian/zfs-modules-_KVERS_.triggers.in
+++ b/debian/zfs-modules-_KVERS_.triggers.in
@@ -1,0 +1,1 @@
+activate update-initramfs

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -7,7 +7,7 @@ subdir-m += unicode
 subdir-m += zcommon
 subdir-m += zfs
 
-INSTALL_MOD_DIR ?= extra
+INSTALL_MOD_DIR ?= updates
 
 ZFS_MODULE_CFLAGS += -std=gnu99 -Wno-declaration-after-statement
 ZFS_MODULE_CFLAGS += @KERNEL_DEBUG_CFLAGS@


### PR DESCRIPTION
The intention is to have our Delphix ZFS modules be prioritized over stock Ubuntu ZFS modules that come with the kernel.
Our original approach was to remove/dpkg-divert the modules provided by Ubuntu, however it comes at the cost of modifying the original kernel package.
There's a more elegant solution that leverages the depmod hierarchy on Linux systems, more specifically there's an order for where the system looks for kernel modules (see /etc/depmod.d/ubuntu.conf).
This change installs Delphix ZFS modules into `/lib/modules/KERNEL/updates/` instead of the default directory `extra/`.

### Testing
* pre-push: http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/zfs-package-build/job/master/job/pre-push/8/console (pass)
* Build appliance with the new ZFS modules and check that it boots and that the proper ZFS modules are used.
* Test that git-zfs-make/load works properly and that the new modules are used.

