### PR TITLE
LX-1144 Set MODULES=most when building initramfs

### DIFF
--- a/contrib/initramfs/conf-hooks.d/zfs
+++ b/contrib/initramfs/conf-hooks.d/zfs
@@ -1,2 +1,16 @@
 # Force the inclusion of Busybox in the initramfs.
 BUSYBOX=y
+
+# Workaround for https://bugs.launchpad.net/ubuntu/+source/initramfs-tools/+bug/1661629
+#
+# When building an initrd with MODULES=dep, which ubuntu tries to do when
+# installing kdump-tools, mkinitramfs tries to detect which modules are
+# necessary based on the hardware and filesystem, and include only those
+# moules in the image.
+#
+# However, the detection logic doesn't understand zfs on root, so building the
+# initramfs fails. As a workaround, override MODULES to get mkinitramfs to just
+# includes most modules without checking whether they are really needed. The
+# result is a larger initrd image than is strictly necessary, but at least it is
+# created successfully.
+MODULES=most


### PR DESCRIPTION

A workaround for the fact that Ubuntu's mkinitramfs script does not understand zfs on root (https://bugs.launchpad.net/ubuntu/+source/initramfs-tools/+bug/1661629). This change will make it possible to build an initrd for a kdump kernel, and thus allow us to gather crashdumps.

Because this makes initrd images larger, and because this workaround is only necessary when using zfs on root, this change probably isn't generally useful, so it should probably be kept specific to Delphix, and removed when the Ubuntu bug is fixed.

### Testing
- Applied this change using `git zfs-make` and `git zfs-load`, then made sure I could successfully install the `kdump-tools` package, which builds an initrd for kdump as part of its post install scripts.