### PR TITLE
LX-1114 Missing utilities causing zfstest failures

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -156,7 +156,7 @@ Description: OpenZFS Event Daemon
 Package: zfs-test
 Section: contrib/admin
 Architecture: linux-any
-Depends: ${misc:Depends}, ${shlibs:Depends}, zfs-modules | zfs-dkms, zfsutils-linux (>=${binary:Version}), parted, lsscsi, mdadm, bc, ksh, fio, acl, sudo, sysstat, python
+Depends: ${misc:Depends}, ${shlibs:Depends}, zfs-modules | zfs-dkms, zfsutils-linux (>=${binary:Version}), parted, lsscsi, mdadm, bc, ksh, fio, acl, sudo, sysstat, python, attr
 Breaks: zfsutils-linux (<= 0.6.5.11-1)
 Replaces: zfsutils-linux (<= 0.6.5.11-1)
 Description: OpenZFS test infrastructure an support scripts

--- a/debian/control.in
+++ b/debian/control.in
@@ -156,7 +156,7 @@ Description: OpenZFS Event Daemon
 Package: zfs-test
 Section: contrib/admin
 Architecture: linux-any
-Depends: ${misc:Depends}, ${shlibs:Depends}, zfs-modules | zfs-dkms, zfsutils-linux (>=${binary:Version}), parted, lsscsi, mdadm, bc, ksh, fio, acl, sudo, sysstat, python
+Depends: ${misc:Depends}, ${shlibs:Depends}, zfs-modules | zfs-dkms, zfsutils-linux (>=${binary:Version}), parted, lsscsi, mdadm, bc, ksh, fio, acl, sudo, sysstat, python, attr
 Breaks: zfsutils-linux (<= 0.6.5.11-1)
 Replaces: zfsutils-linux (<= 0.6.5.11-1)
 Description: OpenZFS test infrastructure an support scripts


### PR DESCRIPTION
This introduces a dependency in the zfstest package on `attr`, the lack
of which causes failures in the following tests:

    features/large_dnode/large_dnode_002_pos
    projectquota/projectid_003_pos
    rsend/send_realloc_dnode_size
    slog/slog_replay_fs
    xattr/xattr_001_pos
    xattr/xattr_003_neg
    xattr/xattr_004_pos
    xattr/xattr_005_pos
    xattr/xattr_006_pos
    xattr/xattr_007_neg
    xattr/xattr_011_pos
    xattr/xattr_013_pos

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
