### PR TITLE
override built-in zfs modules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -146,7 +146,8 @@ override_dh_install:
 # ------------
 
 override_dh_prep-deb-files:
-	for templ in $(wildcard $(CURDIR)/debian/*_KVERS_*.in); do \
+	for templ in $(wildcard $(CURDIR)/debian/*_KVERS_*.in) \
+		$$(find $(CURDIR)/debian/tree/zfs-modules -name '*_KVERS_*.in'); do \
 		sed -e 's/##KVERS##/$(KVERS)/g ; s/#KVERS#/$(KVERS)/g ; s/_KVERS_/$(KVERS)/g ; s/##KDREV##/$(KDREV)/g ; s/#KDREV#/$(KDREV)/g ; s/_KDREV_/$(KDREV)/g ; s/_ARCH_/$(DEB_HOST_ARCH)/' \
 		< $$templ > `echo $$templ | sed -e 's/_KVERS_/$(KVERS)/g ; s/_ARCH_/$(DEB_HOST_ARCH)/g ; s/\.in$$//'` ; \
 	done

--- a/debian/tree/zfs-modules/etc/depmod.d/zfs-modules-_KVERS_.conf.in
+++ b/debian/tree/zfs-modules/etc/depmod.d/zfs-modules-_KVERS_.conf.in
@@ -1,0 +1,12 @@
+#
+# This ensures that custom built modules override built-in modules provided
+# with the kernel
+#
+override icp _KVERS_ extra
+override spl _KVERS_ extra
+override zavl _KVERS_ extra
+override zcommon _KVERS_ extra
+override zfs _KVERS_ extra
+override zlua _KVERS_ extra
+override znvpair _KVERS_ extra
+override zunicode _KVERS_ extra

--- a/debian/zfs-modules-_KVERS_.install.in
+++ b/debian/zfs-modules-_KVERS_.install.in
@@ -1,8 +1,9 @@
-module/zcommon/zcommon.ko	lib/modules/_KVERS_/updates/zcommon/
-module/zfs/zfs.ko		lib/modules/_KVERS_/updates/zfs/
-module/avl/zavl.ko		lib/modules/_KVERS_/updates/avl/
-module/unicode/zunicode.ko	lib/modules/_KVERS_/updates/unicode/
-module/nvpair/znvpair.ko	lib/modules/_KVERS_/updates/nvpair/
-module/icp/icp.ko		lib/modules/_KVERS_/updates/icp/
-module/lua/zlua.ko		lib/modules/_KVERS_/updates/lua/
-module/spl/spl.ko		lib/modules/_KVERS_/updates/spl/
+debian/tree/zfs-modules/etc/depmod.d/zfs-modules-_KVERS_.conf	etc/depmod.d/
+module/zcommon/zcommon.ko	lib/modules/_KVERS_/extra/zcommon/
+module/zfs/zfs.ko		lib/modules/_KVERS_/extra/zfs/
+module/avl/zavl.ko		lib/modules/_KVERS_/extra/avl/
+module/unicode/zunicode.ko	lib/modules/_KVERS_/extra/unicode/
+module/nvpair/znvpair.ko	lib/modules/_KVERS_/extra/nvpair/
+module/icp/icp.ko		lib/modules/_KVERS_/extra/icp/
+module/lua/zlua.ko		lib/modules/_KVERS_/extra/lua/
+module/spl/spl.ko		lib/modules/_KVERS_/extra/spl/

--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -7,7 +7,7 @@ subdir-m += unicode
 subdir-m += zcommon
 subdir-m += zfs
 
-INSTALL_MOD_DIR ?= updates
+INSTALL_MOD_DIR ?= extra
 
 ZFS_MODULE_CFLAGS += -std=gnu99 -Wno-declaration-after-statement
 ZFS_MODULE_CFLAGS += @KERNEL_DEBUG_CFLAGS@


### PR DESCRIPTION
The objective of this change is to revert back the change that installs
ZFS modules into the updates directory, and instead provide a rule that
specifies where to look by default for each ZFS module.

### Testing:
Generate packages: http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/zfs-package-build/job/master/job/pre-push/20/console (pass)
Appliance-build: http://ops.jenkins.delphix.com/job/devops-gate/job/projects/job/dx4linux/job/appliance-build/job/master/job/pre-push/128/console (pass)

Note that when I tested it manually, it seems like Delphix ZFS modules were used even without the overrides. Will need to investigate more why is that so.