### PR TITLE
Rely on appliance-build to set tunables correctly

### DIFF
--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -71,7 +71,7 @@ unsigned long zfs_per_txg_dirty_frees_percent = 30;
 /*
  * Enable/disable forcing txg sync when dirty in dmu_offset_next.
  */
-int zfs_dmu_offset_next_sync = 1;
+int zfs_dmu_offset_next_sync = 0;
 
 /*
  * This can be used for testing, to ensure that certain actions happen

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -99,7 +99,7 @@ int zfs_metaslab_condense_block_threshold = 4;
  * eligible to allocate on any metaslab group. The default value of 0 means
  * no metaslab group will be excluded based on this criterion.
  */
-int zfs_mg_noalloc_threshold = 5;
+int zfs_mg_noalloc_threshold = 0;
 
 /*
  * Metaslab groups are considered eligible for allocations if their

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -340,12 +340,8 @@ char *zfs_deadman_failmode = "wait";
  * the block may be dittoed with up to 3 DVAs by ddt_sync().  All together,
  * the worst case is:
  *     (VDEV_RAIDZ_MAXPARITY + 1) * SPA_DVAS_PER_BP * 2 == 24
- *
- * DelphixOS does not use RAID-Z or dedup.  The worst case is 3 copies in
- * the DVAs, and one extra copy for good luck (e.g. ganging, which is not
- * accounted for in the above "worst case" analysis).
  */
-int spa_asize_inflation = SPA_DVAS_PER_BP + 1;
+int spa_asize_inflation = 24;
 
 /*
  * Normally, we don't allow the last 3.2% (1/(2^spa_slop_shift)) of space in

--- a/module/zfs/vdev_queue.c
+++ b/module/zfs/vdev_queue.c
@@ -142,13 +142,13 @@ uint32_t zfs_vdev_max_active = 1000;
  * more quickly, but reads and writes to have higher latency and lower
  * throughput.
  */
-uint32_t zfs_vdev_sync_read_min_active = 35;
-uint32_t zfs_vdev_sync_read_max_active = 35;
-uint32_t zfs_vdev_sync_write_min_active = 35;
-uint32_t zfs_vdev_sync_write_max_active = 35;
+uint32_t zfs_vdev_sync_read_min_active = 10;
+uint32_t zfs_vdev_sync_read_max_active = 10;
+uint32_t zfs_vdev_sync_write_min_active = 10;
+uint32_t zfs_vdev_sync_write_max_active = 10;
 uint32_t zfs_vdev_async_read_min_active = 1;
-uint32_t zfs_vdev_async_read_max_active = 10;
-uint32_t zfs_vdev_async_write_min_active = 1;
+uint32_t zfs_vdev_async_read_max_active = 3;
+uint32_t zfs_vdev_async_write_min_active = 2;
 uint32_t zfs_vdev_async_write_max_active = 10;
 uint32_t zfs_vdev_scrub_min_active = 1;
 uint32_t zfs_vdev_scrub_max_active = 2;
@@ -171,7 +171,7 @@ int zfs_vdev_async_write_active_max_dirty_percent = 60;
  * we include spans of optional I/Os to aid aggregation at the disk even when
  * they aren't able to help us aggregate at this level.
  */
-int zfs_vdev_aggregation_limit = SPA_OLD_MAXBLOCKSIZE;
+int zfs_vdev_aggregation_limit = 1 << 20;
 int zfs_vdev_read_gap_limit = 32 << 10;
 int zfs_vdev_write_gap_limit = 4 << 10;
 


### PR DESCRIPTION
This change reverts a couple of commits that previously modified tunable
parameters directly in our ZFS codebase. Now, with the integration of
delphix/appliance-build#91, we want to undo this work and rely on
appliance-build to set these tunable values correctly.