### PR TITLE
Add size estimate override tunable to list of module parameters

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1667,6 +1667,18 @@ Default value: \fB1,048,576\fR.
 .sp
 .ne 2
 .na
+\fBzfs_allow_redacted_dataset_mount\fR (int)
+.ad
+.RS 12n
+Allow datasets received with redacted send/receive to be mounted. Normally
+disabled because these datasets may be missing key data.
+.sp
+Default value: \fB0\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_metaslab_fragmentation_threshold\fR (int)
 .ad
 .RS 12n
@@ -2151,13 +2163,60 @@ Use \fB1\fR for yes and \fB0\fR for no (default).
 .sp
 .ne 2
 .na
+\fBzfs_send_no_prefetch_queue_ff\fR (int)
+.ad
+.RS 12n
+The fill fraction of the \fBzfs send\fR internal queues. The fill fraction
+controls the timing with which internal threads are woken up.
+.sp
+Default value: \fB20\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_send_no_prefetch_queue_length\fR (int)
+.ad
+.RS 12n
+The maximum number of bytes allowed in \fBzfs send\fR's internal queues.
+.sp
+Default value: \fB1,048,576\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_send_queue_ff\fR (int)
+.ad
+.RS 12n
+The fill fraction of the \fBzfs send\fR prefetch queue. The fill fraction
+controls the timing with which internal threads are woken up.
+.sp
+Default value: \fB20\fR.
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_send_queue_length\fR (int)
 .ad
 .RS 12n
-The maximum number of bytes allowed in the \fBzfs send\fR queue. This value
-must be at least twice the maximum block size in use.
+The maximum number of bytes allowed that will be prefetched by \fBzfs send\fR.
+This value must be at least twice the maximum block size in use.
 .sp
 Default value: \fB16,777,216\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_recv_queue_ff\fR (int)
+.ad
+.RS 12n
+The fill fraction of the \fBzfs receive\fR queue. The fill fraction
+controls the timing with which internal threads are woken up.
+.sp
+Default value: \fB20\fR.
 .RE
 
 .sp
@@ -2171,6 +2230,21 @@ The maximum number of bytes allowed in the \fBzfs receive\fR queue. This value
 must be at least twice the maximum block size in use.
 .sp
 Default value: \fB16,777,216\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_override_estimate_recordsize\fR (ulong)
+.ad
+.RS 12n
+Setting this variable overrides the default logic for estimating block
+sizes when doing a zfs send. The default heuristic is that the average
+block size will be the current recordsize. Override this value if most data
+in your dataset is not of that size and you require accurate zfs send size
+estimates.
+.sp
+Default value: \fB0\fR.
 .RE
 
 .sp

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -94,7 +94,7 @@ int zfs_send_no_prefetch_queue_ff = 20;
 /*
  * Use this to override the recordsize calculation for fast zfs send estimates.
  */
-uint64_t zfs_override_estimate_recordsize = 0;
+int zfs_override_estimate_recordsize = 0;
 
 /* Set this tunable to FALSE to disable setting of DRR_FLAG_FREERECORDS */
 int zfs_send_set_freerecords_bit = B_TRUE;
@@ -2866,4 +2866,8 @@ MODULE_PARM_DESC(zfs_send_queue_ff, "Send queue fill fraction");
 module_param(zfs_send_no_prefetch_queue_ff, int, 0644);
 MODULE_PARM_DESC(zfs_send_no_prefetch_queue_ff,
 	"Send queue fill fraction for non-prefetch queues");
+
+module_param(zfs_override_estimate_recordsize, int, 0644);
+MODULE_PARM_DESC(zfs_override_estimate_recordsize,
+	"Override block size estimate with fixed size");
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change exposes the zfs_override_estimate_recordsize tunable as a module parameter.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
