### PR TITLE
Fixes for raw receives

### DIFF
--- a/lib/libzfs/libzfs_sendrecv.c
+++ b/lib/libzfs/libzfs_sendrecv.c
@@ -3993,6 +3993,7 @@ recv_skip(libzfs_handle_t *hdl, int fd, boolean_t byteswap)
 			    P2ROUNDUP(drr->drr_u.drr_write_embedded.drr_psize,
 			    8), B_FALSE, NULL);
 			break;
+		case DRR_OBJECT_RANGE:
 		case DRR_WRITE_BYREF:
 		case DRR_FREEOBJECTS:
 		case DRR_FREE:

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -2556,6 +2556,9 @@ dmu_recv_stream(dmu_recv_cookie_t *drc, int cleanup_fd,
 		    keynvl, drc->drc_newfs);
 		if (err != 0)
 			goto out;
+
+                if (!drc->drc_newfs)
+                        drc->drc_keynvl = fnvlist_dup(keynvl);
 	}
 
 	if (drc->drc_featureflags & DMU_BACKUP_FEATURE_RESUMING) {


### PR DESCRIPTION
These small fixes for raw receives will be part of the upstream redacted send/recv commits when they land, we should include them in our repo now to avoid merge conflicts or possible issues.