### PR TITLE
LX-1396 umount failed (part deux)

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -3904,8 +3904,26 @@ zfs_do_set(int argc, char **argv)
 		}
 	}
 
+	/*
+	 * Lock the sharetab to ensure concurrent writers don't update
+	 * the file simultaneously.
+	 */
+	boolean_t sharetab_lock_required = B_FALSE;
+	if (nvlist_exists(props, zfs_prop_to_name(ZFS_PROP_SHARENFS))) {
+		if (sharetab_lock() != 0) {
+			(void) fprintf(stderr, gettext("unable to set "
+			    "property: %s\n"), strerror(errno));
+			ret = -1;
+			goto error;
+		}
+		sharetab_lock_required = B_TRUE;
+	}
+
 	ret = zfs_for_each(argc - ds_start, argv + ds_start, 0,
 	    ZFS_TYPE_DATASET, NULL, NULL, 0, set_callback, props);
+
+	if (sharetab_lock_required)
+		verify(sharetab_unlock() == 0);
 
 error:
 	nvlist_free(props);

--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -3905,8 +3905,8 @@ zfs_do_set(int argc, char **argv)
 	}
 
 	/*
-	 * Lock the sharetab to ensure concurrent writers don't update
-	 * the file simultaneously.
+	 * If we are setting the sharenfs property, lock the sharetab to
+	 * ensure concurrent writers don't update the file simultaneously.
 	 */
 	boolean_t sharetab_lock_required = B_FALSE;
 	if (nvlist_exists(props, zfs_prop_to_name(ZFS_PROP_SHARENFS))) {

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1573,12 +1573,15 @@ zpool_do_destroy(int argc, char **argv)
 		return (1);
 	}
 
+	verify(sharetab_lock() == 0);
 	if (zpool_disable_datasets(zhp, force) != 0) {
 		(void) fprintf(stderr, gettext("could not destroy '%s': "
 		    "could not unmount datasets\n"), zpool_get_name(zhp));
 		zpool_close(zhp);
+		verify(sharetab_unlock() == 0);
 		return (1);
 	}
+	verify(sharetab_unlock() == 0);
 
 	/* The history must be logged as part of the export */
 	log_history = B_FALSE;
@@ -1603,8 +1606,12 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 {
 	export_cbdata_t *cb = data;
 
-	if (zpool_disable_datasets(zhp, cb->force) != 0)
+	verify(sharetab_lock() == 0);
+	if (zpool_disable_datasets(zhp, cb->force) != 0) {
+		verify(sharetab_unlock() == 0);
 		return (1);
+	}
+	verify(sharetab_unlock() == 0);
 
 	/* The history must be logged as part of the export */
 	log_history = B_FALSE;

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -64,6 +64,7 @@
 #include <math.h>
 
 #include <libzfs.h>
+#include <libshare.h>
 
 #include "zpool_util.h"
 #include "zfs_comutil.h"
@@ -2671,12 +2672,15 @@ do_import(nvlist_t *config, const char *newname, const char *mntopts,
 			ret = 1;
 	}
 
+	verify(sharetab_lock() == 0);
 	if (zpool_get_state(zhp) != POOL_STATE_UNAVAIL &&
 	    !(flags & ZFS_IMPORT_ONLY) &&
 	    zpool_enable_datasets(zhp, mntopts, 0) != 0) {
 		zpool_close(zhp);
+		verify(sharetab_unlock() == 0);
 		return (1);
 	}
+	verify(sharetab_unlock() == 0);
 
 	zpool_close(zhp);
 	return (ret);

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -173,18 +173,18 @@ sharetab_lock(void)
 {
 	struct flock lock;
 
-	assert(sharetab_fd == -1);
+	verify(sharetab_fd == -1);
 
 	if (mkdir("/etc/dfs", 0755) < 0 && errno != EEXIST) {
 		perror("sharetab_lock: failed to create /etc/dfs");
-		return (-1);
+		return (errno);
 	}
 
 	sharetab_fd = open(ZFS_SHARETAB_LOCK, (O_RDWR | O_CREAT), 0600);
 
 	if (sharetab_fd < 0) {
 		perror("sharetab_lock: failed to open");
-		return (-1);
+		return (errno);
 	}
 
 	lock.l_type = F_WRLCK;
@@ -193,7 +193,7 @@ sharetab_lock(void)
 	lock.l_len = 0;
 	if (fcntl(sharetab_fd, F_SETLKW, &lock) < 0) {
 		perror("sharetab_lock: failed to lock");
-		return (-1);
+		return (errno);
 	}
 	return (0);
 }
@@ -227,7 +227,6 @@ update_sharetab(sa_handle_impl_t impl_handle)
 	char tempfile[] = ZFS_SHARETAB".XXXXXX";
 	sa_fstype_t *fstype;
 	const char *resource;
-
 
 	temp_fd = mkstemp(tempfile);
 
@@ -502,9 +501,6 @@ sa_fini(sa_handle_t handle)
 	}
 
 	update_sharetab(impl_handle);
-
-	if (impl_handle->zfs_libhandle != NULL)
-		libzfs_fini(impl_handle->zfs_libhandle);
 
 	impl_share = impl_handle->shares;
 	while (impl_share != NULL) {

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -502,6 +502,9 @@ sa_fini(sa_handle_t handle)
 
 	update_sharetab(impl_handle);
 
+	if (impl_handle->zfs_libhandle != NULL)
+		libzfs_fini(impl_handle->zfs_libhandle);
+
 	impl_share = impl_handle->shares;
 	while (impl_share != NULL) {
 		next = impl_share->next;

--- a/lib/libshare/libshare.c
+++ b/lib/libshare/libshare.c
@@ -217,7 +217,6 @@ sharetab_unlock(void)
 	return (retval);
 }
 
-
 static void
 update_sharetab(sa_handle_impl_t impl_handle)
 {

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -873,7 +873,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL, 0))
 		return (0);
 
-	verify(sharetab_lock() == 0);
 	for (curr_proto = proto; *curr_proto != PROTO_END; curr_proto++) {
 		/*
 		 * Return success if there are no share options.
@@ -889,7 +888,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 			(void) zfs_error_fmt(hdl, EZFS_SHARENFSFAILED,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s': %s"),
 			    zfs_get_name(zhp), sa_errorstr(ret));
-			verify(sharetab_unlock() == 0);
 			return (-1);
 		}
 
@@ -921,7 +919,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    proto_table[*curr_proto].p_share_err,
 				    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 				    zfs_get_name(zhp));
-				verify(sharetab_unlock() == 0);
 				return (-1);
 			}
 			hdl->libzfs_shareflags |= ZFSSHARE_MISS;
@@ -937,7 +934,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    proto_table[*curr_proto].p_share_err,
 				    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 				    zfs_get_name(zhp));
-				verify(sharetab_unlock() == 0);
 				return (-1);
 			}
 		} else {
@@ -945,12 +941,10 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 			    proto_table[*curr_proto].p_share_err,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s'"),
 			    zfs_get_name(zhp));
-			verify(sharetab_unlock() == 0);
 			return (-1);
 		}
 
 	}
-	verify(sharetab_unlock() == 0);
 	return (0);
 }
 


### PR DESCRIPTION
This change provides a coarse-grain file lock to the `zfs` and `zpool` commands to prevent concurrent updates to the `/etc/dfs/sharetab` file.  The lock is grabbed whenever we to call `zfs set sharenfs` or when we `zpool destroy` or `zpool export` the pool. This is meant as a hack to allow our testing to complete successfully as it does not protect against concurrent updates when commands use `-o sharenfs` property to update the nfs settings. We rely on the fact that our stack currently only sets the `sharenfs` property by calling `zfs set`.
