### PR TITLE
Simplify changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-zfs-linux (_DELPHIX_PKG_VERSION_-_DELPHIX_PKG_REVISION_) UNRELEASED; urgency=medium
-
-  * Delphix trunk release
-
- -- Pavel Zakharov <pavel.zakharov@delphix.com>  Mon, 16 Apr 2018 19:42:09 +0000
-
 zfs-linux (0.7.5-1ubuntu14) bionic; urgency=medium
 
   * Clean up symlink'd /etc/zfs/zed.d/zed-functions.sh (LP: #1757939)


### PR DESCRIPTION
### Description
We can leverage the `dch` command to auto-generate the appropriate changelog entry.
This change is should be pushed along with devops-gate TOOL-6540, as those 2 changes depend on each other.

### How Has This Been Tested?
http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/zfs-package-build/job/master/job/pre-push/16/consoleFull

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
- [ ] Change has been approved by a ZFS on Linux member.
