### PR TITLE
DLPX-62162 ZFS fails to build following changes to move to python3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -42,6 +42,7 @@ endif
 	  --with-udevdir=/lib/udev \
 	  --with-systemdunitdir=/lib/systemd/system \
 	  --with-systemdpresetdir=/lib/systemd/system-preset \
+	  --with-python=3 \
 	  --with-config=user \
 	  --enable-debuginfo
 
@@ -53,14 +54,11 @@ override_dh_auto_install:
 	@# Install the utilities.
 	$(MAKE) install DESTDIR='$(CURDIR)/debian/tmp'
 
- 
 	# Move from bin_dir to /usr/sbin
-	# Remove suffix (.py) as per policy 10.4 - Scripts
-	# https://www.debian.org/doc/debian-policy/ch-files.html#s-scripts
 	mkdir -p '$(CURDIR)/debian/tmp/usr/sbin/'
-	mv '$(CURDIR)/debian/tmp/usr/bin/arc_summary.py' '$(CURDIR)/debian/tmp/usr/sbin/arc_summary'
-	mv '$(CURDIR)/debian/tmp/usr/bin/arcstat.py' '$(CURDIR)/debian/tmp/usr/sbin/arcstat'
-	mv '$(CURDIR)/debian/tmp/usr/bin/dbufstat.py' '$(CURDIR)/debian/tmp/usr/sbin/dbufstat'
+	mv '$(CURDIR)/debian/tmp/usr/bin/arc_summary' '$(CURDIR)/debian/tmp/usr/sbin/arc_summary'
+	mv '$(CURDIR)/debian/tmp/usr/bin/arcstat' '$(CURDIR)/debian/tmp/usr/sbin/arcstat'
+	mv '$(CURDIR)/debian/tmp/usr/bin/dbufstat' '$(CURDIR)/debian/tmp/usr/sbin/dbufstat'
 
 	@# Zed has dependencies outside of the system root.
 	$(INSTALL) -d '$(CURDIR)/debian/tmp/usr/sbin/'

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -22,7 +22,6 @@ sbin/zhack
 sbin/zdb
 sbin/zpool
 sbin/zfs
-usr/bin/arc_summary3.py
 usr/bin/zgenhostid
 usr/sbin/arc_summary
 usr/sbin/arcstat


### PR DESCRIPTION
### Description
Fix issues with packaging following recent merge with upstream.

### How Has This Been Tested?
- Re-built packages, installed manually on a system and checked that arc_summary works.
- pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/356/

### Notes
- By default `configure.sh` auto-detects which version of python to build against. We want to manually specify the version of python since our build environment is not the same as the runtime environment.
- Related git-utils change: https://jira.delphix.com/browse/TOOL-7032