### PR TITLE
Handle BOOKMARK_V2

### DIFF
--- a/include/sys/dsl_pool.h
+++ b/include/sys/dsl_pool.h
@@ -165,6 +165,7 @@ void dsl_free_sync(zio_t *pio, dsl_pool_t *dp, uint64_t txg,
 void dsl_pool_create_origin(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_upgrade_clones(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_upgrade_dir_clones(dsl_pool_t *dp, dmu_tx_t *tx);
+void dsl_pool_sync_bookmark_featureflags(dsl_pool_t *dp, dmu_tx_t *tx);
 void dsl_pool_mos_diduse_space(dsl_pool_t *dp,
     int64_t used, int64_t comp, int64_t uncomp);
 void dsl_pool_ckpoint_diduse_space(dsl_pool_t *dp,


### PR DESCRIPTION
Upstream, the bookmark_v2 errata problem is being handled with respect to encryption by asking users to recreate their encrypted datasets. We can't ask our users to recreate all their bookmarks. As a result, we take this alternative approach; when the feature is enabled but not active during spa_sync, and either of its dependencies are active, we iterate over all the bookmarks in the pool and increment the v2 featureflag for each one that would have incremented either of the flags that depend on it.

This code was tested by moving pools from an Illumos VM to a linux VM with these bits loaded, and then enabling the feature and deleting bookmarks. Without these bits, that causes the kernel panic described in the bug report.  In addition, the changes passed ab-pre-push.