### PR TITLE
DLPX-62600 zfs sharenfs commands make slow progress on scalability sy…

### DIFF
--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1635,12 +1635,9 @@ zpool_export_one(zpool_handle_t *zhp, void *data)
 {
 	export_cbdata_t *cb = data;
 
-	verify(sharetab_lock() == 0);
 	if (zpool_disable_datasets(zhp, cb->force) != 0) {
-		verify(sharetab_unlock() == 0);
 		return (1);
 	}
-	verify(sharetab_unlock() == 0);
 
 	/* The history must be logged as part of the export */
 	log_history = B_FALSE;
@@ -1714,7 +1711,9 @@ zpool_do_export(int argc, char **argv)
 		usage(B_FALSE);
 	}
 
+	verify(sharetab_lock() == 0);
 	ret = for_each_pool(argc, argv, B_TRUE, NULL, zpool_export_one, &cb);
+	verify(sharetab_unlock() == 0);
 
 	return (ret);
 }

--- a/lib/libspl/include/libshare.h
+++ b/lib/libspl/include/libshare.h
@@ -85,6 +85,7 @@ extern int sa_disable_share(sa_share_t, char *);
 
 extern int sharetab_lock(void);
 extern int sharetab_unlock(void);
+extern boolean_t sharetab_locked(void);
 
 /* protocol specific interfaces */
 extern int sa_parse_legacy_options(sa_group_t, char *, char *);


### PR DESCRIPTION
This change enables caching the MNTTAB (/proc/self/mounts) when we initialize libshare. In a test run with 8500 filesystems we can see that a single `zfs sharenfs` command takes 5 seconds with this change compared to 67 seconds without.