### PR TITLE
Handle record swapping between Linux and DxOS

### DIFF
--- a/include/libzfs_core.h
+++ b/include/libzfs_core.h
@@ -97,6 +97,8 @@ int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, boolean_t,
     int);
 int lzc_receive_resumable(const char *, nvlist_t *, const char *, boolean_t,
     boolean_t, int);
+int lzc_receive_resumable_illumos(const char *, nvlist_t *, const char *,
+    boolean_t, boolean_t, int);
 int lzc_receive_with_header(const char *, nvlist_t *, const char *, boolean_t,
     boolean_t, boolean_t, int, const struct dmu_replay_record *);
 int lzc_receive_one(const char *, nvlist_t *, const char *, boolean_t,

--- a/include/sys/dmu_recv.h
+++ b/include/sys/dmu_recv.h
@@ -50,6 +50,7 @@ typedef struct dmu_recv_cookie {
 	boolean_t drc_force;
 	boolean_t drc_resumable;
 	boolean_t drc_clone;
+	boolean_t drc_illumos;
 	struct avl_tree *drc_guid_to_ds_map;
 	nvlist_t *drc_keynvl;
 	uint64_t drc_fromsnapobj;
@@ -79,8 +80,8 @@ typedef struct dmu_recv_cookie {
 
 int dmu_recv_begin(char *tofs, char *tosnap,
     struct dmu_replay_record *drr_begin, boolean_t force, boolean_t resumable,
-    nvlist_t *localprops, nvlist_t *hidden_args, char *origin,
-    dmu_recv_cookie_t *drc, vnode_t *vp, offset_t *voffp);
+    boolean_t illumos, nvlist_t *localprops, nvlist_t *hidden_args,
+    char *origin, dmu_recv_cookie_t *drc, vnode_t *vp, offset_t *voffp);
 int dmu_recv_stream(dmu_recv_cookie_t *drc, int cleanup_fd,
     uint64_t *action_handlep, offset_t *voffp);
 int dmu_recv_end(dmu_recv_cookie_t *drc, void *owner);

--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -1080,9 +1080,9 @@ dmu_recv_resume_begin_sync(void *arg, dmu_tx_t *tx)
  */
 int
 dmu_recv_begin(char *tofs, char *tosnap, dmu_replay_record_t *drr_begin,
-    boolean_t force, boolean_t resumable, nvlist_t *localprops,
-    nvlist_t *hidden_args, char *origin, dmu_recv_cookie_t *drc,
-    vnode_t *vp, offset_t *voffp)
+    boolean_t force, boolean_t resumable, boolean_t illumos,
+    nvlist_t *localprops, nvlist_t *hidden_args, char *origin,
+    dmu_recv_cookie_t *drc, vnode_t *vp, offset_t *voffp)
 {
 	dmu_recv_begin_arg_t drba = { 0 };
 	int err;
@@ -1094,6 +1094,7 @@ dmu_recv_begin(char *tofs, char *tosnap, dmu_replay_record_t *drr_begin,
 	drc->drc_tofs = tofs;
 	drc->drc_force = force;
 	drc->drc_resumable = resumable;
+	drc->drc_illumos = illumos;
 	drc->drc_cred = CRED();
 	drc->drc_clone = (origin != NULL);
 
@@ -2136,6 +2137,16 @@ static int
 receive_read_record(dmu_recv_cookie_t *drc)
 {
 	int err;
+	/*
+	 * We should revert the commit that added this logic once we no longer
+	 * support FCR from 5.3 or earlier.
+	 */
+	if (drc->drc_illumos) {
+		if (drc->drc_rrd->header.drr_type == DRR_OBJECT_RANGE)
+			drc->drc_rrd->header.drr_type = DRR_REDACT;
+		else
+			ASSERT3U(drc->drc_rrd->header.drr_type, !=, DRR_REDACT);
+	}
 
 	switch (drc->drc_rrd->header.drr_type) {
 	case DRR_OBJECT:


### PR DESCRIPTION
This change swaps the incoming REDACT and OBJECT_RANGE records if the send stream is being received from Illumos. This change is only applicable for Delphix customers, where the DRR_REDACT record had a different value in earlier releases. This has been tested in conjunction with appstack changes to handle the modified API. Pushing needs to be coordinated with those changes.