### PR TITLE
DLPX-64179 definition of SEC in spl/time.h collides with bcc in traci…

### DIFF
--- a/include/spl/sys/time.h
+++ b/include/spl/sys/time.h
@@ -38,7 +38,6 @@
 #define	TIME_MIN			INT32_MIN
 #endif
 
-#define	SEC				1
 #define	MILLISEC			1000
 #define	MICROSEC			1000000
 #define	NANOSEC				1000000000
@@ -49,8 +48,8 @@
 #define	USEC2NSEC(m)	((hrtime_t)(m) * (NANOSEC / MICROSEC))
 #define	NSEC2USEC(n)	((n) / (NANOSEC / MICROSEC))
 
-#define	NSEC2SEC(n)	((n) / (NANOSEC / SEC))
-#define	SEC2NSEC(m)	((hrtime_t)(m) * (NANOSEC / SEC))
+#define	NSEC2SEC(n)	((n) / NANOSEC)
+#define	SEC2NSEC(m)	((hrtime_t)(m) * NANOSEC)
 
 static const int hz = HZ;
 


### PR DESCRIPTION
…ng scripts

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tracing scripts that attempt to include zfs include files will not load and report an error like this:

{{In file included from /virtual/main.c:6:
In file included from /export/home/delphix/zfs/include/sys/zio.h:35:
In file included from /export/home/delphix/zfs/include/sys/zfs_context.h:38:
In file included from /export/home/delphix/zfs/include/spl/sys/condvar.h:33:
/export/home/delphix/zfs/include/spl/sys/time.h:41:9: warning: 'SEC' macro
redefined [-Wmacro-redefined]
#define SEC 1
^
/virtual/include/bcc/helpers.h:54:9: note: previous definition is here
#define SEC(NAME) _attribute_((section(NAME), used))
^}}

### Description
<!--- Describe your changes in detail -->
This change simply changes the SEC #define in spl/time.h to ONESEC.  

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

- I manually built and installed the new bits on a system and verified that bcc scripts with zfs includes would run. 
- pre-push : http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/4533/


