### PR TITLE
"local-fs.target" shouldn't depend on "zfs-mount.service"

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -2,6 +2,7 @@
 Description=Import ZFS pools by cache file
 Documentation=man:zpool(8)
 DefaultDependencies=no
+After=local-fs.target
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -2,6 +2,7 @@
 Description=Import ZFS pools by device scanning
 Documentation=man:zpool(8)
 DefaultDependencies=no
+After=local-fs.target
 Requires=systemd-udev-settle.service
 After=systemd-udev-settle.service
 After=cryptsetup.target

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -5,7 +5,6 @@ DefaultDependencies=no
 After=systemd-udev-settle.service
 After=zfs-import.target
 After=systemd-remount-fs.service
-Before=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The "zfs-mount.service" is responsible for mounting all ZFS datasets on
a Delphix appliance, including all domain0 mounts. On an appliance with
thousands of domain0 datasets (e.g. thousands of VDBs), it's expected
for the "zfs-mount.service" to take a relatively long time to start
(compared to most other bootup services). Thus, we don't want to cause
that to add latency to the entire bootup process, since lots (nearly
all) services have a dependency on "local-fs.target".

Thus, this change removes the "zfs-mount.service" dependency from the
"local-fs.target". This way, "local-fs.target" will start up, while the
domain0 mounts can proceed without blocking other bootup critical
services. This can safely be done because we rely on "/etc/fstab" for
mounting all of the root filesystem datasets, which do not use
"zfs-mount.service" and are already dependencies of "local-fs.target".

Thus, after this change, any service that depends on the root filesystem
datasets being mounted can depend on the "local-fs.target" (which is in
the default set of service dependencies). Any services that depends on
all domain0 datasets being mounted (e.g. NFS, iSCSI, etc.) can depend
explicitly on the "zfs-mount.service".