### PR TITLE
DLPX-64566 Migration failed due to failure to import domain0

### DIFF
--- a/debian/zfsutils-linux.postinst
+++ b/debian/zfsutils-linux.postinst
@@ -3,7 +3,11 @@
 case $1 in
 configure)
 	systemctl enable zfs-import-cache.service
-	systemctl enable zfs-import-scan.service
+	# Explicitly disable the zfs-import-scan service as it
+	# can unexpectedly import pools that we either want to
+	# stay exported or we want to import with different
+	# arguments.
+	systemctl disable zfs-import-scan.service
 	systemctl enable zfs-import.target
 	systemctl enable zfs-mount.service
 	systemctl enable zfs-share.service


### PR DESCRIPTION
The zfs-import-scan service will run only when `/etc/zfs/zpool.cache` is missing and perform `zpool import -aN -o cachefile=none`.

This service is very different from Illumos, where only pools in zpool.cache are loaded, so the behaviour of automatically importing pools that are not in zpool.cache is very unexpected for most folks at Delphix and can potentially cause issues to support, which expect that domain0 will not be imported when zpool.cache is removed.

During Illumos to Linux migration, zpool.cache is not carried over, so the zfs-import-scan service will kick-off. Due to how service dependencies are layed out, the delphix-migration service will also start at the same time, and both will attempt to import domain0. The zfs-import-scan service will always fail because it doesn't pass `-f`, but it can interfere with the import in delphix-migration and cause it to fail too.

Since the zfs-import-scan service doesn't bring in any value to the product, but does cause a lot of drawbacks, we should just disable it.

Note that I've intentionally left the "systemctl disable zfs-import-scan.service" call  in the postrm script.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1412/
- @grwilson has managed to manually reproduce the failure in described in the bug. Note that it is a race condition that is very sensitive to timing.