### PR TITLE
Create new service that waits on zvol links to be created

### DIFF
--- a/debian/tree/zfsutils-linux/usr/lib/zfs-linux/zvol-wait
+++ b/debian/tree/zfsutils-linux/usr/lib/zfs-linux/zvol-wait
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#
+# Create an array of existing zvols
+#
+readarray -t zvols < <(zfs list -t volume -H -o name)
+echo "Testing ${#zvols[@]} zvol links"
+
+#shellcheck disable=SC2034
+for outer_loop in {1..15}; do
+	#
+	# Test each zvol link, and remove zvol from array if link
+	# is present.
+	#
+	remaining=${#zvols[@]}
+	for inner_loop in {1..60}; do
+		for i in "${!zvols[@]}"; do
+			[[ -e /dev/${zvols[$i]} ]] && unset "zvols[$i]"
+		done
+
+		new_remaining=${#zvols[@]}
+		if [[ $new_remaining -eq 0 ]]; then
+			udevadm settle
+			exit 0
+		fi
+		sleep 1
+	done
+
+	echo "Still waiting on $new_remaining zvol links ..."
+	#
+	# Although zvols should normally not be deleted at boot time,
+	# if that is the case then their links will be missing and
+	# we would stall.
+	#
+	if [[ $new_remaining -eq $remaining ]]; then
+		echo "No progress since last loop."
+		echo "Checking if any zvols were deleted."
+		for i in "${!zvols[@]}"; do
+			if ! zfs list "${zvols[$i]}" &>/dev/null; then
+				echo "${zvols[$i]} was deleted."
+				unset "zvols[$i]"
+			fi
+		done
+		if [[ ${#zvols[@]} -ne 0 ]]; then
+			echo "Remaining zvols:"
+			for zvol in "${zvols[@]}"; do
+				echo "$zvol"
+			done
+		fi
+	fi
+done
+
+echo "Timed out waiting on zvol links"
+exit 1

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -5,6 +5,7 @@ lib/systemd/system/zfs-import-scan.service
 lib/systemd/system/zfs-import-cache.service
 lib/systemd/system/zfs.target
 lib/systemd/system/zfs-import.target
+lib/systemd/system/zfs-zvol-wait.service
 lib/systemd/system-preset/
 usr/lib/systemd/system-generators/zfs-mount-generator
 usr/lib/modules-load.d/ lib/

--- a/debian/zfsutils-linux.postinst
+++ b/debian/zfsutils-linux.postinst
@@ -11,6 +11,7 @@ configure)
 	systemctl enable zfs-import.target
 	systemctl enable zfs-mount.service
 	systemctl enable zfs-share.service
+	systemctl enable zfs-zvol-wait.service
 	systemctl enable zfs.target
 	;;
 esac

--- a/debian/zfsutils-linux.prerm
+++ b/debian/zfsutils-linux.prerm
@@ -7,6 +7,7 @@ upgrade | remove)
 	systemctl disable zfs-import.target
 	systemctl disable zfs-mount.service
 	systemctl disable zfs-share.service
+	systemctl disable zfs-zvol-wait.service
 	systemctl disable zfs.target
 	;;
 esac

--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -5,4 +5,5 @@ enable zfs-import.target
 enable zfs-mount.service
 enable zfs-share.service
 enable zfs-zed.service
+enable zfs-zvol-wait.service
 enable zfs.target

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -8,6 +8,7 @@ systemdunit_DATA = \
 	zfs-mount.service \
 	zfs-share.service \
 	zfs-import.target \
+	zfs-zvol-wait.service \
 	zfs.target
 
 EXTRA_DIST = \
@@ -17,6 +18,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/systemd/system/zfs-mount.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-share.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-import.target.in \
+	$(top_srcdir)/etc/systemd/system/zfs-zvol-wait.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs.target.in \
 	$(top_srcdir)/etc/systemd/system/50-zfs.preset.in
 

--- a/etc/systemd/system/zfs-zvol-wait.service.in
+++ b/etc/systemd/system/zfs-zvol-wait.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=Wait for ZFS Volume (zvol) /dev links
+DefaultDependencies=no
+After=systemd-udev-settle.service
+After=zfs-import.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/zfs-linux/zvol-wait
+
+[Install]
+WantedBy=zfs.target


### PR DESCRIPTION
This is a prerequisite for [DLPX-64724](https://jira.delphix.com/browse/DLPX-64724) (rtslib-fb-targetctl service should wait on domain0 zvol links before starting).

## Open questions

Is a timeout waiting on the zvol links the right approach, or should we just wait forever?

## Testing
- zfs checkstyle: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/25
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1490/
- Added dependency `zfs-zvol-wait.service` to `rtslib-fb-targetctl`. Then created 500 zvols on rpool and domain0 and added all of them as iscsi backstores. Rebooted the system and made sure that rtslib-fb-targetctl didn't report any errors when starting due to unavailable zvols. Here is the service output:
	```
	Jun 26 19:08:43 pzakha-lx-4.dcenter systemd[1]: Starting Wait for ZFS Volume (zvol) /dev links...
	Jun 26 19:08:45 pzakha-lx-4.dcenter zvol-wait[14906]: Testing 1004 zvol links
	Jun 26 19:08:45 pzakha-lx-4.dcenter zvol-wait[14906]: All zvol links are created.
	Jun 26 19:08:45 pzakha-lx-4.dcenter zvol-wait[14906]: Running 'udevadm settle'.
	Jun 26 19:08:45 pzakha-lx-4.dcenter systemd[1]: Started Wait for ZFS Volume (zvol) /dev links.
	```
- Tested logic where a zvol is deleted while the script is running by adding "test code" to the script. Here is the output:
	```
	Jun 26 19:14:27 pzakha-lx-4.dcenter systemd[1]: Starting Wait for ZFS Volume (zvol) /dev links...
	Jun 26 19:14:29 pzakha-lx-4.dcenter zvol-wait[19918]: Testing 1004 zvol links
	Jun 26 19:14:29 pzakha-lx-4.dcenter zvol-wait[19918]: TEST CODE: Deleting rpool/ZVOLS/zvol333
	Jun 26 19:15:31 pzakha-lx-4.dcenter zvol-wait[19918]: Still waiting on 1 zvol links ...
	Jun 26 19:16:31 pzakha-lx-4.dcenter zvol-wait[19918]: Still waiting on 1 zvol links ...
	Jun 26 19:16:31 pzakha-lx-4.dcenter zvol-wait[19918]: No progress since last loop.
	Jun 26 19:16:31 pzakha-lx-4.dcenter zvol-wait[19918]: Checking if any zvols were deleted.
	Jun 26 19:16:31 pzakha-lx-4.dcenter zvol-wait[19918]: rpool/ZVOLS/zvol333 was deleted.
	Jun 26 19:16:31 pzakha-lx-4.dcenter zvol-wait[19918]: All zvol links are created.
	Jun 26 19:16:31 pzakha-lx-4.dcenter zvol-wait[19918]: Running 'udevadm settle'.
	Jun 26 19:16:31 pzakha-lx-4.dcenter systemd[1]: Started Wait for ZFS Volume (zvol) /dev links.
	```
