### PR TITLE
Enable zfs-volumes.target by default

### DIFF
--- a/debian/zfsutils-linux.postinst
+++ b/debian/zfsutils-linux.postinst
@@ -12,6 +12,7 @@ configure)
 	systemctl enable zfs-mount.service
 	systemctl enable zfs-share.service
 	systemctl enable zfs-volume-wait.service
+	systemctl enable zfs-volumes.target
 	systemctl enable zfs.target
 	;;
 esac

--- a/debian/zfsutils-linux.prerm
+++ b/debian/zfsutils-linux.prerm
@@ -8,6 +8,7 @@ upgrade | remove)
 	systemctl disable zfs-mount.service
 	systemctl disable zfs-share.service
 	systemctl disable zfs-volume-wait.service
+	systemctl disable zfs-volumes.target
 	systemctl disable zfs.target
 	;;
 esac

--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -6,4 +6,5 @@ enable zfs-mount.service
 enable zfs-share.service
 enable zfs-zed.service
 enable zfs-volume-wait.service
+enable zfs-volumes.target
 enable zfs.target


### PR DESCRIPTION
This service was integrated upstream with https://github.com/zfsonlinux/zfs/pull/8975, however it is disabled by default.

We want to enable it on the Delphix Engine as a prerequisite for https://jira.delphix.com/browse/DLPX-64724.

## Testing
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1813/