### PR TITLE
ESTALE file handles can occur when nfs-server restarts 

### DIFF
--- a/etc/systemd/system/zfs-share.service.in
+++ b/etc/systemd/system/zfs-share.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=ZFS file system shares
 Documentation=man:zfs(8)
-After=nfs-server.service nfs-kernel-server.service
 After=smb.service
+Before=nfs-config.service
 Before=rpc-statd-notify.service
 Wants=zfs-mount.service
 After=zfs-mount.service
@@ -12,8 +12,7 @@ PartOf=smb.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=-/bin/rm -f /etc/dfs/sharetab
-ExecStart=@sbindir@/zfs share -a
+ExecStart=@sbindir@/zfs share -g
 
 [Install]
 WantedBy=zfs.target

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
  * Copyright Joyent, Inc.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2016, Intel Corporation.
@@ -791,6 +791,7 @@ extern boolean_t zfs_is_shared_smb(zfs_handle_t *, char **);
 extern int zfs_share_nfs(zfs_handle_t *);
 extern int zfs_share_smb(zfs_handle_t *);
 extern int zfs_shareall(zfs_handle_t *);
+extern int zfs_share_generate(zfs_handle_t *);
 extern int zfs_unshare_nfs(zfs_handle_t *, const char *);
 extern int zfs_unshare_smb(zfs_handle_t *, const char *);
 extern int zfs_unshareall_nfs(zfs_handle_t *);

--- a/include/libzfs_impl.h
+++ b/include/libzfs_impl.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
  * Copyright (c) 2018 Datto Inc.
  */
 
@@ -204,6 +204,8 @@ extern int zfs_parse_options(char *, zfs_share_proto_t);
 
 extern int zfs_unshare_proto(zfs_handle_t *,
     const char *, zfs_share_proto_t *);
+int nfs_exports_lock(void);
+int nfs_exports_unlock(void);
 
 #ifdef	__cplusplus
 }

--- a/lib/libshare/libshare_impl.h
+++ b/lib/libshare/libshare_impl.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Gunnar Beutner
+ * Copyright (c) 2019 by Delphix. All rights reserved.
  */
 
 struct sa_handle_impl;
@@ -50,7 +51,9 @@ typedef struct sa_share_ops {
 	int (*disable_share)(sa_share_impl_t share);
 	int (*validate_shareopts)(const char *shareopts);
 	int (*update_shareopts)(sa_share_impl_t impl_share,
-	    const char *resource, const char *shareopts);
+	    const char *resource, const char *shareopts,
+		boolean_t skip_reshare);
+	int (*generate_share)(sa_share_impl_t share);
 	void (*clear_shareopts)(sa_share_impl_t impl_share);
 } sa_share_ops_t;
 

--- a/lib/libshare/smb.c
+++ b/lib/libshare/smb.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011,2012 Turbo Fredriksson <turbo@bayour.com>, based on nfs.c
  *                         by Gunnar Beutner
+ * Copyright (c) 2019 by Delphix. All rights reserved.
  *
  * This is an addition to the zfs device driver to add, modify and remove SMB
  * shares using the 'net share' command that comes with Samba.
@@ -381,7 +382,7 @@ smb_is_share_active(sa_share_impl_t impl_share)
  */
 static int
 smb_update_shareopts(sa_share_impl_t impl_share, const char *resource,
-    const char *shareopts)
+    const char *shareopts, boolean_t skip_reshare)
 {
 	char *shareopts_dup;
 	boolean_t needs_reshare = B_FALSE;
@@ -411,10 +412,17 @@ smb_update_shareopts(sa_share_impl_t impl_share, const char *resource,
 
 	FSINFO(impl_share, smb_fstype)->shareopts = shareopts_dup;
 
-	if (needs_reshare)
+	if (needs_reshare && !skip_reshare)
 		smb_enable_share(impl_share);
 
 	return (SA_OK);
+}
+
+static int
+smb_generate_share(sa_share_impl_t impl_share)
+{
+	/* Not implemented */
+	return (0);
 }
 
 /*
@@ -434,6 +442,7 @@ static const sa_share_ops_t smb_shareops = {
 
 	.validate_shareopts = smb_validate_shareopts,
 	.update_shareopts = smb_update_shareopts,
+    .generate_share = smb_generate_share,
 	.clear_shareopts = smb_clear_shareopts,
 };
 

--- a/lib/libspl/include/libshare.h
+++ b/lib/libspl/include/libshare.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2019 by Delphix. All rights reserved.
  */
 #ifndef _LIBSPL_LIBSHARE_H
 #define	_LIBSPL_LIBSHARE_H
@@ -82,6 +83,7 @@ extern char *sa_errorstr(int);
 extern sa_share_t sa_find_share(sa_handle_t, char *);
 extern int sa_enable_share(sa_group_t, char *);
 extern int sa_disable_share(sa_share_t, char *);
+extern int sa_generate_share(const char *, const char *);
 
 extern int sharetab_lock(void);
 extern int sharetab_unlock(void);

--- a/lib/libzfs/libzfs_mount.c
+++ b/lib/libzfs/libzfs_mount.c
@@ -1000,6 +1000,21 @@ zfs_shareall(zfs_handle_t *zhp)
 	return (zfs_share_proto(zhp, share_all_proto));
 }
 
+int
+zfs_share_generate(zfs_handle_t *zhp)
+{
+	char mountpoint[ZFS_MAXPROPLEN];
+	char shareopts[ZFS_MAXPROPLEN];
+
+	if (!zfs_is_mountable(zhp, mountpoint, sizeof (mountpoint), NULL, 0))
+		return (0);
+
+	verify(zfs_prop_get(zhp, ZFS_PROP_SHARENFS, shareopts,
+	    sizeof (shareopts), NULL, NULL, 0, B_FALSE) == 0);
+
+	return (sa_generate_share(mountpoint, shareopts));
+}
+
 /*
  * Unshare a filesystem by mountpoint.
  */

--- a/tests/zfs-tests/include/libtest.shlib
+++ b/tests/zfs-tests/include/libtest.shlib
@@ -22,7 +22,7 @@
 #
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
-# Copyright (c) 2012, 2018 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2019 by Delphix. All rights reserved.
 # Copyright (c) 2017 by Tim Chase. All rights reserved.
 # Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
 # Copyright (c) 2017 Lawrence Livermore National Security, LLC.
@@ -1313,6 +1313,36 @@ function is_shared
 	fi
 
 	is_shared_impl "$fs"
+}
+
+function is_exported
+{
+	typeset fs=$1
+	typeset mtpt
+
+	if is_linux; then
+		if [[ $fs != "/"* ]] ; then
+			if datasetnonexists "$fs" ; then
+				return 1
+			else
+				mtpt=$(get_prop mountpoint "$fs")
+				case $mtpt in
+					none|legacy|-) return 1
+						;;
+					*)	fs=$mtpt
+						;;
+				esac
+			fi
+		fi
+		for mtpt in `awk '{print $1}' /etc/exports.d/zfs.exports` ; do
+			if [[ $mtpt == $fs ]] ; then
+				return 0
+			fi
+		done
+
+		return 1
+	fi
+
 }
 
 #

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2019 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -71,6 +71,8 @@ function cleanup
 	if snapexists "$TESTPOOL/$TESTFS@snapshot"; then
 		log_must zfs destroy -f $TESTPOOL/$TESTFS@snapshot
 	fi
+
+	log_must zfs share -ag
 }
 
 
@@ -138,10 +140,21 @@ done
 #
 log_must zfs share -a
 
+#
+# We need to unset __ZFS_POOL_EXCLUDE so that we include all file systems
+# into the /etc/exports.d/zfs.exports file. We will restore the contents
+# of this file on cleanup.
+#
+unset __ZFS_POOL_EXCLUDE
+log_must zfs share -g
+
 i=0
 while (( i < ${#fs[*]} )); do
 	is_shared ${fs[i]} || \
 	    log_fail "File system ${fs[i]} is not shared (share -a)"
+
+	is_exported ${fs[i]} || \
+	    log_fail "File system ${fs[i]} is not exported (share -ag)"
 
 	((i = i + 2))
 done


### PR DESCRIPTION
DLPX-63546 Deleting vdb with additional mount point provisioned from a staged dsource causes dsource stale filehandle
DLPX-64357 Oracle can abort with ESTALE file handles when a Linux DVE is rebooted (regression)

When the `nfs-server.service` restart, it will also restart the `zfs-share.service` and `nfs-mountd.service`. Since the `zfs-share.service` currently runs after the `nfs-server.service` it creates a gap where an NFS client could request an NFS mount for a filesystem which has not yet been shared. This can happen when the NFS server is restarted or the engine is rebooted.

To overcome this gap, this fix introduces a new option to `zfs share` which generates a file which is compatible with the NFS service. This file is named `/etc/exports.d/zfs.exports` and hold all the exported filesystems that exist at the time that the `zfs-share` service is invoked. The file is removed and recreated whenever this service runs. It also changes the dependency of the `zfs-share` service to run before `nfs-server.service`. Since the `zfs-share` service no longer invokes `exportfs` on each shared filesystem, there is no need for it to require that the NFS service is up and running. The `nfs-server.service` already knows to export any filesystems which exist in `/etc/exports.d/` so just processes them upon start or restarts.

Testing this on one of the scalability systems with over 5000+ filesystems (of which 1100 are shared) we see the following times to run `zfs share -a` vs `zfs share -g`:

`zfs share -a` : 300 seconds
`zfs share -g`: 7 seconds