### PR TITLE
DLPX-65453 delete /etc/exports.d/zfs.exports after it's used

### DIFF
--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -1,6 +1,7 @@
 ../tree/zfsutils-linux/* /
 lib/systemd/system/zfs-mount.service
 lib/systemd/system/zfs-share.service
+lib/systemd/system/zfs-share-cleanup.service
 lib/systemd/system/zfs-import-scan.service
 lib/systemd/system/zfs-import-cache.service
 lib/systemd/system/zfs.target

--- a/debian/zfsutils-linux.postinst
+++ b/debian/zfsutils-linux.postinst
@@ -11,6 +11,7 @@ configure)
 	systemctl enable zfs-import.target
 	systemctl enable zfs-mount.service
 	systemctl enable zfs-share.service
+	systemctl enable zfs-share-cleanup.service
 	systemctl enable zfs-volume-wait.service
 	systemctl enable zfs-volumes.target
 	systemctl enable zfs.target

--- a/debian/zfsutils-linux.prerm
+++ b/debian/zfsutils-linux.prerm
@@ -7,6 +7,7 @@ upgrade | remove)
 	systemctl disable zfs-import.target
 	systemctl disable zfs-mount.service
 	systemctl disable zfs-share.service
+	systemctl disable zfs-share-cleanup.service
 	systemctl disable zfs-volume-wait.service
 	systemctl disable zfs-volumes.target
 	systemctl disable zfs.target

--- a/etc/systemd/system/50-zfs.preset.in
+++ b/etc/systemd/system/50-zfs.preset.in
@@ -4,6 +4,7 @@ disable zfs-import-scan.service
 enable zfs-import.target
 enable zfs-mount.service
 enable zfs-share.service
+enable zfs-share-cleanup.service
 enable zfs-zed.service
 enable zfs-volume-wait.service
 enable zfs-volumes.target

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -7,6 +7,7 @@ systemdunit_DATA = \
 	zfs-import-scan.service \
 	zfs-mount.service \
 	zfs-share.service \
+	zfs-share-cleanup.service \
 	zfs-volume-wait.service \
 	zfs-import.target \
 	zfs-volumes.target \
@@ -18,6 +19,7 @@ EXTRA_DIST = \
 	$(top_srcdir)/etc/systemd/system/zfs-import-scan.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-mount.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-share.service.in \
+	$(top_srcdir)/etc/systemd/system/zfs-share-cleanup.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-import.target.in \
 	$(top_srcdir)/etc/systemd/system/zfs-volume-wait.service.in \
 	$(top_srcdir)/etc/systemd/system/zfs-volumes.target.in \

--- a/etc/systemd/system/zfs-share-cleanup.service.in
+++ b/etc/systemd/system/zfs-share-cleanup.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=ZFS file system shares cleanup
+After=nfs-server.service
+PartOf=nfs-server.service nfs-kernel-server.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/bin/rm -f /etc/exports.d/zfs.exports
+
+[Install]
+WantedBy=zfs.target

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -322,7 +322,7 @@ image which is ZFS aware.
 
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
-    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target
+    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-share-cleanup.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target
 %else
     %define systemd --enable-sysvinit --disable-systemd
 %endif
@@ -370,6 +370,7 @@ if [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --add zfs-import
     /sbin/chkconfig --add zfs-mount
     /sbin/chkconfig --add zfs-share
+    /sbin/chkconfig --add zfs-share-cleanup
     /sbin/chkconfig --add zfs-zed
 fi
 %endif
@@ -399,7 +400,7 @@ fi
 if [ "$1" = "0" -o "$1" = "remove" ] && [ -x /sbin/chkconfig ]; then
     /sbin/chkconfig --del zfs-import
     /sbin/chkconfig --del zfs-mount
-    /sbin/chkconfig --del zfs-share
+    /sbin/chkconfig --del zfs-share-cleanup
     /sbin/chkconfig --del zfs-zed
 fi
 %endif


### PR DESCRIPTION
This adds a simple service to cleanup the `/etc/exports.d/zfs.exports` file after it's been consumed by the `nfs-server.service`. The idea behind this change is to make sure that nobody is confused by the fact that the `zfs.exports` file is only valid at the time the `zfs-share.service` runs and it will grow stale as more shares and unshares take place. 

This service should be removed when we do the the NFS sharing redesign.