### PR TITLE
fix log spacemap mismerge

### DIFF
--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -76,7 +76,6 @@ typeset -a properties=(
     "feature@obsolete_counts"
     "feature@zpool_checkpoint"
     "feature@spacemap_v2"
-    "feature@log_spacemap"
     "feature@redaction_bookmarks"
     "feature@redacted_datasets"
     "feature@bookmark_written"


### PR DESCRIPTION
In the specific test `"feature@log_spacemap"` is checked twice. I deleted one of the occurences and this file should no longer have diffs with upstream ZoL.

When this PR makes it to `delphix/zfs` and https://github.com/zfsonlinux/zfs/pull/9143 makes it to ZoL we should no longer have diffs in this file and `spa_log_spacemap.c`.

Precommit: http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/4709/