### PR TITLE
DLPX-66105 storageTotal of system info reduces after migration

### DIFF
--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -1776,8 +1776,18 @@ spa_get_checkpoint_space(spa_t *spa)
 void
 spa_update_dspace(spa_t *spa)
 {
-	spa->spa_dspace = metaslab_class_get_dspace(spa_normal_class(spa)) +
-	    ddt_get_dedup_dspace(spa);
+	uint64_t dspace = metaslab_class_get_dspace(spa_normal_class(spa));
+	dspace += ddt_get_dedup_dspace(spa);
+
+	/*
+	 * If there are no log devices, the log space comes from the embedded
+	 * log metaslabs.  This space can be shared with normal allocations,
+	 * so we include it in the available space. See also the comment in
+	 * spa_prop_get_config.
+	 */
+	if (!spa_has_log_device(spa))
+		dspace += metaslab_class_get_dspace(spa_log_class(spa));
+
 	if (spa->spa_vdev_removal != NULL) {
 		/*
 		 * We can't allocate from the removing device, so
@@ -1795,10 +1805,11 @@ spa_update_dspace(spa_t *spa)
 		spa_config_enter(spa, SCL_VDEV, FTAG, RW_READER);
 		vdev_t *vd =
 		    vdev_lookup_top(spa, spa->spa_vdev_removal->svr_vdev_id);
-		spa->spa_dspace -= spa_deflate(spa) ?
+		dspace -= spa_deflate(spa) ?
 		    vd->vdev_stat.vs_dspace : vd->vdev_stat.vs_space;
 		spa_config_exit(spa, SCL_VDEV, FTAG);
 	}
+	spa->spa_dspace = dspace;
 }
 
 /*


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is similar to DLPX-65985, but in this case the issue is that the space accounting at the DMU level (i.e. "zfs list") is not including the space in the embedded LOG metaslabs. We need to add this in spa_update_dspace().

### Description
<!--- Describe your changes in detail -->
Add the embedded log space in spa_update_dspace.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->


Note that `zpool list` output is the same, but `zfs list`'s `AVAIL` is different.

5.3:
```
$ zpool list -v test
NAME         SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP  HEALTH  ALTROOT
test        22.5G   167K  22.5G        -         -     0%     0%  1.00x  ONLINE  -
  c2t1d0    7.50G  59.5K  7.50G        -         -     0%     0%
  c2t2d0    7.50G    48K  7.50G        -         -     0%     0%
  c2t3d0    7.50G  59.5K  7.50G        -         -     0%     0%
$ zfs list test
NAME   USED  AVAIL  REFER  MOUNTPOINT
test   167K  21.8G    23K  /test
```

trunk:
```
$ zpool list -v test
NAME        SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
test       22.5G   112K  22.5G        -         -     0%     0%  1.00x    ONLINE  -
  sdb      7.50G  41.5K  7.50G        -         -     0%  0.00%      -  ONLINE
  sdc      7.50G  29.5K  7.50G        -         -     0%  0.00%      -  ONLINE
  sdd      7.50G  41.5K  7.50G        -         -     0%  0.00%      -  ONLINE
$ zfs list test
NAME   USED  AVAIL     REFER  MOUNTPOINT
test   112K  20.3G       24K  /test
```

trunk + fix:
```
$ zpool list -v test
NAME        SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
test       22.5G   140K  22.5G        -         -     0%     0%  1.00x    ONLINE  -
  sdb      7.50G  50.5K  7.50G        -         -     0%  0.00%      -  ONLINE
  sdc      7.50G  38.5K  7.50G        -         -     0%  0.00%      -  ONLINE
  sdd      7.50G  50.5K  7.50G        -         -     0%  0.00%      -  ONLINE
$ zfs list test
NAME   USED  AVAIL     REFER  MOUNTPOINT
test   140K  21.8G       24K  /test
```

http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/4811/ (failure of rsend.send-c_lz4_disabled seems unrelated to changes)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).