### PR TITLE
Fix dsl_scan issues

### DIFF
--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -2923,6 +2923,10 @@ scan_io_queue_fetch_ext(dsl_scan_io_queue_t *queue)
 		if (zfs_scan_issue_strategy == 1) {
 			return (range_tree_first(rt));
 		} else if (zfs_scan_issue_strategy == 2) {
+			/*
+			 * We need to get the original entry in the by_addr
+			 * tree so we can modify it.
+			 */
 			range_seg_t *size_rs =
 			    zfs_btree_first(&queue->q_exts_by_size, NULL);
 			uint64_t start = rs_get_start(size_rs, rt);
@@ -2930,6 +2934,10 @@ scan_io_queue_fetch_ext(dsl_scan_io_queue_t *queue)
 			range_seg_t *addr_rs = range_tree_find(rt, start,
 			    size);
 			ASSERT3P(addr_rs, !=, NULL);
+			ASSERT3U(rs_get_start(size_rs, rt), ==,
+			    rs_get_start(addr_rs, rt));
+			ASSERT3U(rs_get_end(size_rs, rt), ==,
+			    rs_get_end(addr_rs, rt));
 			return (addr_rs);
 		}
 	}
@@ -2946,12 +2954,19 @@ scan_io_queue_fetch_ext(dsl_scan_io_queue_t *queue)
 	if (scn->scn_checkpointing) {
 		return (range_tree_first(rt));
 	} else if (scn->scn_clearing) {
+		/*
+		 * We need to get the original entry in the by_addr
+		 * tree so we can modify it.
+		 */
 		range_seg_t *size_rs = zfs_btree_first(&queue->q_exts_by_size,
 		    NULL);
 		uint64_t start = rs_get_start(size_rs, rt);
 		uint64_t size = rs_get_end(size_rs, rt) - start;
 		range_seg_t *addr_rs = range_tree_find(rt, start, size);
 		ASSERT3P(addr_rs, !=, NULL);
+		ASSERT3U(rs_get_start(size_rs, rt), ==, rs_get_start(addr_rs,
+		    rt));
+		ASSERT3U(rs_get_end(size_rs, rt), ==, rs_get_end(addr_rs, rt));
 		return (addr_rs);
 	} else {
 		return (NULL);

--- a/module/zfs/dsl_scan.c
+++ b/module/zfs/dsl_scan.c
@@ -2925,8 +2925,10 @@ scan_io_queue_fetch_ext(dsl_scan_io_queue_t *queue)
 		} else if (zfs_scan_issue_strategy == 2) {
 			range_seg_t *size_rs =
 			    zfs_btree_first(&queue->q_exts_by_size, NULL);
-			range_seg_t *addr_rs = range_tree_find(rt,
-			    rs_get_start(rt, size_rs), rs_get_end(rt, size_rs));
+			uint64_t start = rs_get_start(size_rs, rt);
+			uint64_t size = rs_get_end(size_rs, rt) - start;
+			range_seg_t *addr_rs = range_tree_find(rt, start,
+			    size);
 			ASSERT3P(addr_rs, !=, NULL);
 			return (addr_rs);
 		}
@@ -2946,8 +2948,9 @@ scan_io_queue_fetch_ext(dsl_scan_io_queue_t *queue)
 	} else if (scn->scn_clearing) {
 		range_seg_t *size_rs = zfs_btree_first(&queue->q_exts_by_size,
 		    NULL);
-		range_seg_t *addr_rs = range_tree_find(rt,
-		    rs_get_start(rt, size_rs), rs_get_end(rt, size_rs));
+		uint64_t start = rs_get_start(size_rs, rt);
+		uint64_t size = rs_get_end(size_rs, rt) - start;
+		range_seg_t *addr_rs = range_tree_find(rt, start, size);
 		ASSERT3P(addr_rs, !=, NULL);
 		return (addr_rs);
 	} else {


### PR DESCRIPTION
This issues fixes the scrub-related panics that we discovered during additional testing of the btree changes. Some of these errors would have been caught by additional compiler warning flags; these are being tested and may be introduced upstream.

Signed-off-by: Paul Dagnelie <pcd@delphix.com>
