### PR TITLE
Add check for new shares to zfs-share-cleanup

### DIFF
--- a/debian/tree/zfsutils-linux/usr/lib/zfs-linux/share-cleanup
+++ b/debian/tree/zfsutils-linux/usr/lib/zfs-linux/share-cleanup
@@ -1,0 +1,49 @@
+#!/bin/bash -u
+
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+
+#
+# Cleanup the ZFS exports
+#
+# The zfs-share service generates 'zfs.exports' which is consumed by the
+# nfs-server service in ExecStartPre. To catch any zfs shares that were
+# enabled since the zfs-share service started, we must re-generate the
+# 'zfs.exports' file and check for any changes. If there is a delta, we
+# run 'exportfs -r' to export the new additions.
+#
+
+function die() {
+	echo "$(basename $0): $1" >&2
+	# always remove the zfs.exports file
+	if [[ -f "$ZFS_EXPORTS" ]]; then
+		/bin/rm -f "$ZFS_EXPORTS"
+	fi
+	exit 1
+}
+
+ZFS_EXPORTS=/etc/exports.d/zfs.exports
+ZFS_EXPORTS_BAK=${ZFS_EXPORTS}.bak
+
+if [[ -f "$ZFS_EXPORTS" ]]; then
+	# save the zfs-share service generated copy
+	/bin/mv -f "$ZFS_EXPORTS" "$ZFS_EXPORTS_BAK" || die "rename failed"
+
+	# generate a new zfs.exports
+	/sbin/zfs share -g || die "failed to generate zfs exports"
+
+	cmp --silent "$ZFS_EXPORTS" "$ZFS_EXPORTS_BAK"
+	ret=$?
+
+	/bin/rm -f "$ZFS_EXPORTS_BAK"
+
+	# if the zfs.exports content has changed then re-export
+	if [[ $ret -eq 1 ]]; then
+		/usr/sbin/exportfs -r || die "re-exporting failed"
+	fi
+
+	/bin/rm -f "$ZFS_EXPORTS"
+fi
+
+exit 0

--- a/etc/systemd/system/zfs-share-cleanup.service.in
+++ b/etc/systemd/system/zfs-share-cleanup.service.in
@@ -6,7 +6,7 @@ PartOf=nfs-server.service nfs-kernel-server.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=-/bin/rm -f /etc/exports.d/zfs.exports
+ExecStart=-/usr/lib/zfs-linux/share-cleanup
 
 [Install]
 WantedBy=zfs.target


### PR DESCRIPTION
### Motivation and Context
This is a follow on to [PR-64](https://github.com/delphix/zfs/pull/64) which introduced the `zfs share -g` CLI  variant and changed the `zfs-share` service to run _before_ the `nfs-server` service.  With than change, there is now a window from the time the `zfs-share` service generates the `zfs.exports` file and the `nfs-server` startup completes. A `zfs set sharenfs` operation within that window will silently not export the share.

### Description
Extend the zfs-share-cleanup service to re-generate a zfs.imports file and check for any changes. If there is a delta, we run `exportfs -r` to export the new additions.

### How Has This Been Tested?
`$ git ab-pre-push -k --test-upgrade-from 5.3.6.0 --tests`
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2338/

Manually tested that with the proposed fix we pick up the lost exports for any _dropped_ `zfs set sharenfs` operations.