### PR TITLE
ZFS header package should put files in one directory

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -191,6 +191,7 @@ override_dh_binary-modules: override_dh_prep-deb-files override_dh_configure_mod
 	dh_prep
 
 	$(MAKE) -C $(CURDIR)/module modules
+	$(MAKE) -C $(CURDIR)/include install DESTDIR='$(CURDIR)/debian/tmp' VERSION=build
 
 	dh_install -p${pmodules} -p${pheaders}
 	dh_installdocs -p${pmodules} -p${pheaders}

--- a/debian/zfs-headers-_KVERS_.install.in
+++ b/debian/zfs-headers-_KVERS_.install.in
@@ -1,2 +1,2 @@
-include usr/src/zfs-_KVERS_/
+debian/tmp/usr/local/src/zfs-build/include usr/src/zfs-_KVERS_/
 zfs_config.h usr/src/zfs-_KVERS_/


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously we generated the files for the header package by copying
what's in `include` directory of the source tree.  Since the source file
restructuring for ZoF, the header files in the source code were
reorganized into platform-specific subdirectories (for Linux and
FreeBSD).  However, when installed, we want all the header files
together, as they were before the ZoF restructuring.

### Description
<!--- Describe your changes in detail -->
`make install` knows how to arrange the header files from the
platform-specific subdirectories into a single combined directory.  This
change leverages that to generate the directory structure for the header
package.  Specifically, we `make install -C include` into a temporary
directory, and then use that temporary directory to get the files for
the package.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

git-ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2350/

I registered one of the VM's created by ab-pre-push (split-precommit-dxos-26260-66511f0c.dlpxdc.co) and verified that the include directories are how we want them:

```
$ find /usr/src/zfs-4.15.0-1051-aws/include -type d
/usr/src/zfs-4.15.0-1051-aws/include
/usr/src/zfs-4.15.0-1051-aws/include/linux
/usr/src/zfs-4.15.0-1051-aws/include/sys
/usr/src/zfs-4.15.0-1051-aws/include/sys/lua
/usr/src/zfs-4.15.0-1051-aws/include/sys/crypto
/usr/src/zfs-4.15.0-1051-aws/include/sys/fm
/usr/src/zfs-4.15.0-1051-aws/include/sys/fm/fs
/usr/src/zfs-4.15.0-1051-aws/include/sys/fs
/usr/src/zfs-4.15.0-1051-aws/include/sys/sysevent
/usr/src/zfs-4.15.0-1051-aws/include/spl
/usr/src/zfs-4.15.0-1051-aws/include/spl/rpc
/usr/src/zfs-4.15.0-1051-aws/include/spl/sys
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
