### PR TITLE
Small program that converts a dataset id and an object id to a path

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -5,4 +5,4 @@ if USING_PYTHON
 SUBDIRS += arcstat arc_summary dbufstat
 endif
 
-SUBDIRS += mount_zfs zed zvol_id zvol_wait
+SUBDIRS += mount_zfs zed zvol_id zvol_wait zfs_ids_to_path

--- a/cmd/zfs_ids_to_path/.gitignore
+++ b/cmd/zfs_ids_to_path/.gitignore
@@ -1,0 +1,1 @@
+zfs_ids_to_path

--- a/cmd/zfs_ids_to_path/Makefile.am
+++ b/cmd/zfs_ids_to_path/Makefile.am
@@ -1,0 +1,9 @@
+include $(top_srcdir)/config/Rules.am
+
+sbin_PROGRAMS = zfs_ids_to_path
+
+zfs_ids_to_path_SOURCES = \
+	zfs_ids_to_path.c
+
+zfs_ids_to_path_LDADD = \
+        $(top_builddir)/lib/libzfs/libzfs.la

--- a/cmd/zfs_ids_to_path/zfs_ids_to_path.c
+++ b/cmd/zfs_ids_to_path/zfs_ids_to_path.c
@@ -1,3 +1,26 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
 #include <libintl.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -49,4 +72,5 @@ main(int argc, char **argv)
         printf("%s\n", pathname);
         zpool_close(pool);
         libzfs_fini(g_zfs);
+	return (0);
 }

--- a/cmd/zfs_ids_to_path/zfs_ids_to_path.c
+++ b/cmd/zfs_ids_to_path/zfs_ids_to_path.c
@@ -1,0 +1,52 @@
+#include <libintl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <libzfs.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+libzfs_handle_t *g_zfs;
+
+void
+usage(int err)
+{
+        fprintf(stderr, "Usage: ./os_id_to_name <pool> <objset id> <object id>\n");
+        exit(err);
+}
+
+int
+main(int argc, char **argv)
+{
+        if (argc != 4) {
+                (void) fprintf(stderr, "Incorrect number of arguments: %d\n", argc);
+                usage(1);
+        }
+
+        uint64_t objset, object;
+        if (sscanf(argv[2], "%lu", &objset) != 1) {
+                (void) fprintf(stderr, "Invalid objset id: %s\n", argv[2]);
+                usage(2);
+        }
+        if (sscanf(argv[3], "%lu", &object) != 1) {
+                (void) fprintf(stderr, "Invalid object id: %s\n", argv[3]);
+                usage(3);
+        }
+        if ((g_zfs = libzfs_init()) == NULL) {
+                (void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
+                return (4);
+        }
+        zpool_handle_t *pool = zpool_open(g_zfs, argv[1]);
+        if (pool == NULL) {
+                fprintf(stderr, "Could not open pool %s\n", argv[1]);
+                libzfs_fini(g_zfs);
+                return (5);
+        }
+
+        char pathname[PATH_MAX * 2];
+        zpool_obj_to_path(pool, objset, object, pathname, PATH_MAX * 2);
+        printf("%s\n", pathname);
+        zpool_close(pool);
+        libzfs_fini(g_zfs);
+}

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_CONFIG_FILES([
 	cmd/zed/Makefile
 	cmd/zed/zed.d/Makefile
 	cmd/zfs/Makefile
+	cmd/zfs_ids_to_path/Makefile
 	cmd/zgenhostid/Makefile
 	cmd/zhack/Makefile
 	cmd/zinject/Makefile

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -24,6 +24,7 @@ sbin/zstreamdump
 sbin/zinject
 sbin/zhack
 sbin/zdb
+sbin/zfs_ids_to_path
 sbin/zpool
 sbin/zfs
 usr/bin/zgenhostid


### PR DESCRIPTION
This utility accepts a pool name, a dataset id, and an object id, and returns the path to that object. This is useful in a few situations, especially when using tracing tools that may not be able to iterate through an object heirarchy to derive a full path.