### PR TITLE
[Backport of Issue DLPX-66501 to 6.0.0.0] Lumen ARC size should be si…

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7810,19 +7810,22 @@ arc_init(void)
 	arc_need_free = 0;
 #endif
 
-	/* Set max to 1/2 of all memory */
-	arc_c_max = allmem / 2;
-
-#ifdef	_KERNEL
 	/* Set min cache to 1/32 of all memory, or 32MB, whichever is more */
 	arc_c_min = MAX(allmem / 32, 2ULL << SPA_MAXBLOCKSHIFT);
-#else
+	/* set max to 3/4 of all memory, or all but 1GB, whichever is more */
+	if (allmem >= 1 << 30)
+		arc_c_max = allmem - (1 << 30);
+	else
+		arc_c_max = arc_c_min;
+	arc_c_max = MAX(allmem * 3 / 4, arc_c_max);
+
 	/*
 	 * In userland, there's only the memory pressure that we artificially
 	 * create (see arc_available_memory()).  Don't let arc_c get too
 	 * small, because it can cause transactions to be larger than
 	 * arc_c, causing arc_tempreserve_space() to fail.
 	 */
+#ifndef _KERNEL
 	arc_c_min = MAX(arc_c_max / 2, 2ULL << SPA_MAXBLOCKSHIFT);
 #endif
 


### PR DESCRIPTION
[Backport of Issue DLPX-66501 to 6.0.0.0] Lumen ARC size should be similar to 5.3.x

Now that the arc uses ADB buffers, we should be able to increase the
default max size of the arc to match what is used by other platforms.
This change sets the max size of the arc to 3/4 of all memory or all but
1GB, whichever is greater.

Signed-off-by: George Wilson <gwilson@delphix.com>
External-issue: DLPX-66501

