### PR TITLE
DLPX-66733 Backport

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6548,9 +6548,20 @@ share_mount_one(zfs_handle_t *zhp, int op, int flags, char *protocol,
 		    "'canmount' property is set to 'off'\n"), cmdname,
 		    zfs_get_name(zhp));
 		return (1);
-	} else if (canmount == ZFS_CANMOUNT_NOAUTO && !explicit) {
-		return (0);
+	} else if (canmount == ZFS_CANMOUNT_NOAUTO) {
+		/*
+		 * Skip this request when noauto is set and we wanted all
+		 * mounts|shares (i.e. -a) or we're not generating exports
+		 */
+		if (!explicit && !generate)
+			return (0);
 	}
+
+	/*
+	 * When generating shares and the filesystem isn't mounted then skip it
+	 */
+	if (generate && !zfs_is_mounted(zhp, NULL))
+		return (0);
 
 	/*
 	 * If this filesystem is encrypted and does not have


### PR DESCRIPTION
**Backport of Issue DLPX-66733 to 6.0.0.0**

### Motivation and Context
The `zfs share -g` command will skip nfs exports that have their `canmount` property set to `noauto` but otherwise have a valid mountpoint.  For NPM filesystems the `canmount`  and `sync` properties are overridden. This causes the `zfs-share` service to drop their exports.

### How Has This Been Tested?
git ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2529/

Also installed the fix onto an engine that had the condition and the `zfs share -g` now correctly ignores `canmount=noauto` but it is mounted when filtering the datasets to export.