### PR TITLE
6.0/release: maintain existing bookmark zap entry length

### DIFF
--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1042,6 +1042,38 @@ dsl_redaction_list_hold_obj(dsl_pool_t *dp, uint64_t rlobj, void *tag,
 }
 
 /*
+ * Update the ZAP entry for this bookmark with dbn_phys.  This is only for
+ * use with HAS_FBN bookmarks.
+ */
+static void
+dsl_bookmark_update_entry(uint64_t bmobj, dsl_bookmark_node_t *dbn,
+    dmu_tx_t *tx)
+{
+	dsl_pool_t *dp = dmu_tx_pool(tx);
+	uint64_t int_size, num_ints;
+
+	ASSERT(dbn->dbn_phys.zbm_flags & ZBM_FLAG_HAS_FBN);
+
+	/*
+	 * Maintain the existing ZAP entry length.  Entries from the
+	 * illumos-based Delphix product have one less word (omitting
+	 * zbm_ivset_guid).  This ensures that we can bring this pool back
+	 * to the illumos-based product, as long as no new bookmars have
+	 * been created.  We take advantage of this during the migration
+	 * process (from illumos to linux).  This code can be removed
+	 * once migration from illumos is no longer supported.
+	 */
+	VERIFY0(zap_length(dp->dp_meta_objset, bmobj, dbn->dbn_name,
+	    &int_size, &num_ints));
+	ASSERT3U(int_size, ==, sizeof (uint64_t));
+	VERIFY3U(num_ints, >=, (BOOKMARK_PHYS_SIZE_V2 / int_size) - 1);
+
+	VERIFY0(zap_update(dp->dp_meta_objset, bmobj,
+	    dbn->dbn_name, int_size, num_ints,
+	    &dbn->dbn_phys, tx));
+}
+
+/*
  * Snapshot ds is being destroyed.
  *
  * Adjust the "freed_before_next" of any bookmarks between this snap
@@ -1114,10 +1146,7 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 		    compressed;
 		dbn->dbn_phys.zbm_uncompressed_freed_before_next_snap +=
 		    uncompressed;
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
-		    dbn->dbn_name, sizeof (uint64_t),
-		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		dsl_bookmark_update_entry(head->ds_bookmarks_obj, dbn, tx);
 	}
 	dsl_dataset_rele(next, FTAG);
 
@@ -1139,10 +1168,7 @@ dsl_bookmark_ds_destroyed(dsl_dataset_t *ds, dmu_tx_t *tx)
 		}
 		ASSERT(dbn->dbn_phys.zbm_flags & ZBM_FLAG_SNAPSHOT_EXISTS);
 		dbn->dbn_phys.zbm_flags &= ~ZBM_FLAG_SNAPSHOT_EXISTS;
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
-		    dbn->dbn_name, sizeof (uint64_t),
-		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		dsl_bookmark_update_entry(head->ds_bookmarks_obj, dbn, tx);
 		rv = B_TRUE;
 	}
 	dsl_dataset_rele(head, FTAG);
@@ -1194,8 +1220,6 @@ void
 dsl_bookmark_next_changed(dsl_dataset_t *head, dsl_dataset_t *origin,
     dmu_tx_t *tx)
 {
-	dsl_pool_t *dp = dmu_tx_pool(tx);
-
 	/*
 	 * Find the first bookmark that HAS_FBN at the origin snapshot.
 	 */
@@ -1243,10 +1267,7 @@ dsl_bookmark_next_changed(dsl_dataset_t *head, dsl_dataset_t *origin,
 		dsl_bookmark_set_phys(&dbn->dbn_phys, origin);
 		dbn->dbn_phys.zbm_redaction_obj = redaction_obj;
 
-		VERIFY0(zap_update(dp->dp_meta_objset, head->ds_bookmarks_obj,
-		    dbn->dbn_name, sizeof (uint64_t),
-		    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-		    &dbn->dbn_phys, tx));
+		dsl_bookmark_update_entry(head->ds_bookmarks_obj, dbn, tx);
 	}
 }
 
@@ -1297,8 +1318,6 @@ dsl_bookmark_block_killed(dsl_dataset_t *ds, const blkptr_t *bp, dmu_tx_t *tx)
 void
 dsl_bookmark_sync_done(dsl_dataset_t *ds, dmu_tx_t *tx)
 {
-	dsl_pool_t *dp = dmu_tx_pool(tx);
-
 	if (dsl_dataset_is_snapshot(ds))
 		return;
 
@@ -1318,11 +1337,8 @@ dsl_bookmark_sync_done(dsl_dataset_t *ds, dmu_tx_t *tx)
 			 * we can always use the current bookmark struct size.
 			 */
 			ASSERT(dbn->dbn_phys.zbm_flags & ZBM_FLAG_HAS_FBN);
-			VERIFY0(zap_update(dp->dp_meta_objset,
-			    ds->ds_bookmarks_obj,
-			    dbn->dbn_name, sizeof (uint64_t),
-			    sizeof (zfs_bookmark_phys_t) / sizeof (uint64_t),
-			    &dbn->dbn_phys, tx));
+			dsl_bookmark_update_entry(ds->ds_bookmarks_obj,
+			    dbn, tx);
 			dbn->dbn_dirty = B_FALSE;
 		}
 	}


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We get EOVERFLOW (which causes the "Value too large" message) from
zap_entry_read() when trying to read a ZAP entry and the provided buffer
is too small to hold the entire value. In this case we are doing
zap_lookup_impl() in the bookmark zap object (ds_bookmarks_obj).

The dsl_bookmark_phys_t is one word longer on Linux than on (our version
of) illumos. (The additional word is zbm_ivset_guid, used by the
encryption feature.) We aren't creating any bookmarks on linux (before
migration completes), but there are some additional code paths that can
result in updating existing bookmarks to use the new, larger size which
is incompatible with illumos.

Specifically, dsl_bookmark_sync_done() updates bookmarks that are at or
after the most recent snapshot, whenever there's a write to the dataset.
This update increases the size to be incompatible with illumos. Based on
preliminary testing, that seems to be the case we're hitting.
Additionally, when we destroy a snapshot that has bookmarks at or just
before it, we will update those bookmarks via
dsl_bookmark_ds_destroyed().

### Description
<!--- Describe your changes in detail -->

The solution is to maintain the existing bookmark length when updating
the bookmark's FBN values.

External issue: DLPX-67752

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

From @pzakha:
  migration aws:
    http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2582/
    s3://dev-de-images/builds/jenkins-selfservice/devops-gate/master/appliance-build/6.0/release/pre-push/39/internal-qa-aws/internal-qa-aws.migration.tar.gz
  test migration rollback
    http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-chained/2954/consoleFull
    dlpx-5360-bb-chain-2954-4bb90aae
    sudo /opt/delphix/server/bin/upgrade/dx_upg_stress_options --set STRESS_FAIL_BEFORE_CHECKPOINT_DISCARD
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
