### PR TITLE
Make send prefetch thread high priority to resolve performance regres…

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -2083,7 +2083,7 @@ setup_prefetch_thread(struct send_prefetch_thread_arg *spt_arg,
 	spt_arg->smta = smt_arg;
 	spt_arg->issue_prefetches = !dspp->dso->dso_dryrun;
 	(void) thread_create(NULL, 0, send_prefetch_thread, spt_arg, 0,
-	    curproc, TS_RUN, minclsyspri);
+	    curproc, TS_RUN, maxclsyspri);
 }
 
 static int


### PR DESCRIPTION
…sion

This is intended as a workaround until we can understand the root cause of the regression; currently we believe it was introduced sometime during the Lumen development process, but it may be inherent to Linux (in which case, this may actually resemble the final fix).