### PR TITLE
Add some functional tests for embedded slog

### DIFF
--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -777,7 +777,8 @@ tests = ['slog_001_pos', 'slog_002_pos', 'slog_003_pos', 'slog_004_pos',
     'slog_005_pos', 'slog_006_pos', 'slog_007_pos', 'slog_008_neg',
     'slog_009_neg', 'slog_010_neg', 'slog_011_neg', 'slog_012_neg',
     'slog_013_pos', 'slog_014_pos', 'slog_015_neg', 'slog_replay_fs_001',
-    'slog_replay_fs_002', 'slog_replay_volume']
+    'slog_replay_fs_002', 'slog_replay_volume', 'embedded_slog_count',
+    'embedded_slog_removal']
 tags = ['functional', 'slog']
 
 [tests/functional/snapshot]

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2019 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2020 by Delphix. All rights reserved.
 # These variables are used by zfs-tests.sh to constrain which utilities
 # may be used by the suite. The suite will create a directory which is
 # the only element of $PATH and create symlinks from that dir to the
@@ -78,6 +78,7 @@ export SYSTEM_FILES_COMMON='arp
     rmdir
     scp
     script
+    sdb
     sed
     seq
     setfacl

--- a/tests/zfs-tests/include/tunables.cfg
+++ b/tests/zfs-tests/include/tunables.cfg
@@ -74,6 +74,7 @@ VOL_INHIBIT_DEV			UNSUPPORTED			zvol_inhibit_dev
 VOL_MODE			vol.mode			zvol_volmode
 VOL_RECURSIVE			vol.recursive			UNSUPPORTED
 ZEVENT_LEN_MAX			UNSUPPORTED			zfs_zevent_len_max
+ZFS_MAX_EMBEDDED_SLOGS		UNSUPPORTED			zfs_max_embedded_slogs
 ZIO_SLOW_IO_MS			zio.slow_io_ms			zio_slow_io_ms
 %%%%
 while read name FreeBSD Linux; do

--- a/tests/zfs-tests/tests/functional/slog/Makefile.am
+++ b/tests/zfs-tests/tests/functional/slog/Makefile.am
@@ -1,5 +1,7 @@
 pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/slog
 dist_pkgdata_SCRIPTS = \
+	embedded_slog_count.ksh \
+	embedded_slog_removal.ksh \
 	setup.ksh \
 	cleanup.ksh \
 	slog_001_pos.ksh \

--- a/tests/zfs-tests/tests/functional/slog/embedded_slog_count.ksh
+++ b/tests/zfs-tests/tests/functional/slog/embedded_slog_count.ksh
@@ -1,0 +1,61 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/slog/slog.kshlib
+
+#
+# DESCRIPTION:
+#	Verify the correct number of embedded slogs are in use given the
+#	setting of the ZFS_MAX_EMBEDDED_SLOGS tunable.
+#
+# STRATEGY:
+#	1. Create pools after setting the tunable to 0, 1, 3 and 4.
+#	2. For each pool, verify that the number of slogs is appropriate
+#	   given the tunable setting.
+#
+
+verify_runnable "global"
+
+function cleanup_local
+{
+	log_must set_tunable32 ZFS_MAX_EMBEDDED_SLOGS $zfs_max_embedded_slogs
+	cleanup
+}
+log_onexit cleanup_local
+
+log_must setup
+
+zfs_max_embedded_slogs=$(get_tunable ZFS_MAX_EMBEDDED_SLOGS)
+num_pool_devs=$(echo $VDEV | wc -w)
+for num_slogs in 0 1 3 4; do
+	log_must set_tunable32 ZFS_MAX_EMBEDDED_SLOGS $num_slogs
+	log_must zpool create $TESTPOOL $VDEV
+	slogs=$(get_embedded_slog_count $TESTPOOL)
+
+	# The tunable can be higher than the number of vdevs in the pool.
+	expected_num_slogs=$(get_min $num_pool_devs $num_slogs)
+
+	[[ $expected_num_slogs -eq $slogs ]] || \
+	    log_fail "Expected $num_slogs slogs, but got '$slogs'"
+
+	log_must zfs create $TESTPOOL/$TESTFS
+	ziltest $TESTPOOL $TESTPOOL/$TESTFS $VDIR
+
+	log_must zpool destroy $TESTPOOL
+done
+
+log_pass "Expected number of embedded slogs found."

--- a/tests/zfs-tests/tests/functional/slog/embedded_slog_removal.ksh
+++ b/tests/zfs-tests/tests/functional/slog/embedded_slog_removal.ksh
@@ -1,0 +1,60 @@
+#!/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/slog/slog.kshlib
+
+#
+# DESCRIPTION:
+#	Verify that removing a disk with an embeddeed slog is safe, and that a
+#	new embedded slog is created on the next import.
+#
+# STRATEGY:
+#	1. Create a pool with an embedded slog on only one vdev.
+#	2. Remove that vdev, verify the pool has no embedded slogs.
+#	3. Export and import the pool and verify an embedded slog is creatd.
+#
+
+verify_runnable "global"
+
+function cleanup_local
+{
+	log_must set_tunable32 ZFS_MAX_EMBEDDED_SLOGS $zfs_max_embedded_slogs
+	cleanup
+}
+log_onexit cleanup_local
+
+log_must setup
+
+zfs_max_embedded_slogs=$(get_tunable ZFS_MAX_EMBEDDED_SLOGS)
+log_must set_tunable32 ZFS_MAX_EMBEDDED_SLOGS 1
+
+log_must zpool create $TESTPOOL $VDEV
+slog=$(get_embedded_slog_count $TESTPOOL)
+[[ 1 -eq $slog ]] || log_fail "Expected 1 embedded slog, but found $slog"
+
+remove_dev=$(get_embedded_slog_devices $TESTPOOL)
+log_must zpool remove $TESTPOOL $remove_dev
+slog=$(get_embedded_slog_count $TESTPOOL)
+[[ 0 -eq $slog ]] || log_fail "Expected 0 embedded slogs, but got '$slog'"
+
+log_must zpool export $TESTPOOL
+log_must zpool import -d $VDIR $TESTPOOL
+
+slog=$(get_embedded_slog_count $TESTPOOL)
+[[ 1 -eq $slog ]] || log_fail "Expected 1 embedded slog, but found $slog"
+
+log_pass "Removing disk with embedded slog works."

--- a/tests/zfs-tests/tests/functional/slog/slog.kshlib
+++ b/tests/zfs-tests/tests/functional/slog/slog.kshlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2020 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -154,4 +154,185 @@ function verify_slog_device
 	log_note "Can not find device: $device"
 
 	return 1
+}
+
+function get_embedded_slog_devices
+{
+	typeset pool=$1
+	typeset devices
+	typeset cmd
+
+	# Note that the filter operator uses '>' because sdb does not
+	# yet support '!='
+	cmd="spa $pool | vdev | filter obj.vdev_log_mg > 0 | member vdev_path"
+
+	devices=$(echo "$cmd" | sdb -k 2>/dev/null | \
+	    sed -n 's/.*\"\(.*\)\"$/\1/p')
+
+	echo $devices
+}
+
+function get_embedded_slog_count
+{
+	typeset pool=$1
+	typeset count
+
+	count=$(get_embedded_slog_devices $pool | wc -w)
+
+	echo $count
+}
+
+# This test is a direct adaptation of the ziltest.sh
+# script for the ZFS Test Suite.
+function ziltest
+{
+	typeset pool=$1
+	typeset dataset=$2
+	typeset file_dev_dir=$3
+	typeset mntpt=$(get_prop mountpoint $dataset)
+
+	typeset tx_list="TX_CREATE TX_MKDIR TX_MKXATTR TX_SYMLINK TX_REMOVE \
+	    TX_RMDIR TX_LINK TX_RENAME TX_WRITE TX_TRUNCATE TX_SETATTR"
+
+	#
+	# This dd command works around an issue where ZIL records aren't created
+	# after freezing the pool unless a ZIL header already exists. Create a
+	# file synchronously to force ZFS to write one out.
+	#
+	log_must dd if=/dev/zero of=$mntpt/sync \
+	    conv=fdatasync,fsync bs=1 count=1
+
+	#
+	# 2. Freeze the test fs
+	#
+	log_must zpool freeze $pool
+
+	#
+	# 3. Run various user commands that create files, directories and ACLs
+	#
+
+	# TX_CREATE
+	log_must touch $mntpt/a
+
+	# TX_RENAME
+	log_must mv $mntpt/a $mntpt/b
+
+	# TX_SYMLINK
+	log_must touch $mntpt/c
+	log_must ln -s $mntpt/c $mntpt/d
+
+	# TX_LINK
+	log_must touch $mntpt/e
+	log_must ln $mntpt/e $mntpt/f
+
+	# TX_MKDIR
+	log_must mkdir $mntpt/dir_to_delete
+
+	# TX_RMDIR
+	log_must rmdir $mntpt/dir_to_delete
+
+	# Create a simple validation payload
+	log_must mkdir -p $TESTDIR
+	log_must dd if=/dev/urandom of=$mntpt/payload bs=1k count=8
+	log_must eval "sha256sum -b $mntpt/payload >$TESTDIR/checksum"
+
+	# TX_WRITE (small file with ordering)
+	log_must mkfile 1k $mntpt/small_file
+	log_must mkfile 512b $mntpt/small_file
+
+	# TX_CREATE, TX_MKDIR, TX_REMOVE, TX_RMDIR
+	log_must cp -R /usr/share/dict $mntpt
+	log_must rm -rf $mntpt/dict
+
+	# TX_SETATTR
+	log_must touch $mntpt/setattr
+	log_must chmod 567 $mntpt/setattr
+	log_must chgrp root $mntpt/setattr
+	log_must touch -cm -t 201311271200 $mntpt/setattr
+
+	# TX_TRUNCATE (to zero)
+	log_must mkfile 4k $mntpt/truncated_file
+	log_must truncate -s 0 $mntpt/truncated_file
+
+	# TX_WRITE (large file)
+	log_must dd if=/dev/urandom of=$mntpt/large bs=128k count=64 oflag=sync
+
+	# Write zeros, which compress to holes, in the middle of a file
+	log_must dd if=/dev/urandom of=$mntpt/holes.1 bs=128k count=8
+	log_must dd if=/dev/zero of=$mntpt/holes.1 bs=128k count=2
+
+	log_must dd if=/dev/urandom of=$mntpt/holes.2 bs=128k count=8
+	log_must dd if=/dev/zero of=$mntpt/holes.2 bs=128k count=2 seek=2
+
+	log_must dd if=/dev/urandom of=$mntpt/holes.3 bs=128k count=8
+	log_must dd if=/dev/zero of=$mntpt/holes.3 bs=128k count=2 \
+	   seek=2 conv=notrunc
+
+	# TX_MKXATTR
+	log_must mkdir $mntpt/xattr.dir
+	log_must touch $mntpt/xattr.file
+	log_must set_xattr fileattr HelloWorld $mntpt/xattr.dir
+	log_must set_xattr tmpattr HelloWorld $mntpt/xattr.dir
+	log_must rm_xattr fileattr $mntpt/xattr.dir
+
+	log_must set_xattr fileattr HelloWorld $mntpt/xattr.file
+	log_must set_xattr tmpattr HelloWorld $mntpt/xattr.file
+	log_must rm_xattr tmpattr $mntpt/xattr.file
+
+	#
+	# 4. Copy the test fs to temporary location (TESTDIR/copy)
+	#
+	log_must mkdir -p $TESTDIR/copy
+	log_must cp -a $mntpt/* $TESTDIR/copy/
+
+	#
+	# 5. Unmount filesystem and export the pool
+	#
+	# At this stage the test fs is empty again and frozen, the intent log
+	# contains a complete set of deltas to replay.
+	#
+	log_must zfs unmount $dataset
+
+	log_note "Verify transactions to replay:"
+	log_must zdb -iv $dataset
+
+	# Verify that zdb observes records for each type of data recorded
+	typeset tx_seen=$(zdb -iv $dataset | \
+	    awk '{if(n == 1) print $0} /Total/ {n=1}')
+	for i in $tx_list; do
+		echo $tx_seen | grep -q $i || \
+		    log_fail "zdb did not find record type $i"
+	done
+
+	log_must zpool export $pool
+
+	#
+	# 6. Remount the test fs <which replays the intent log>
+	#
+	# Import the pool to unfreeze it and claim log blocks.  It has to be
+	# `zpool import -f` because we can't write a frozen pool's labels!
+	#
+	[[ -n $file_dev_dir ]] && file_dev_dir="-d $file_dev_dir"
+	log_must zpool import -f $file_dev_dir $pool
+
+	#
+	# 7. Compare the test fs against the TESTDIR/copy
+	#
+	log_note "Verify current block usage:"
+	log_must zdb -bcv $pool
+
+	log_note "Verify copy of xattrs:"
+	log_must ls_xattr /$TESTPOOL/$TESTFS/xattr.dir
+	log_must ls_xattr /$TESTPOOL/$TESTFS/xattr.file
+
+	log_note "Verify working set diff:"
+	log_must diff -r $mntpt $TESTDIR/copy
+
+	log_note "Verify file checksum:"
+	log_must sha256sum -c $TESTDIR/checksum
+
+	#
+	# Cleaunup the data left in $TESTDIR
+	#
+	rm -rf $TESTDIR/*
 }


### PR DESCRIPTION

### Motivation and Context
This change adds some functional tests for embedded slog.

### Description
These tests verify the functionality of the tunable that governs how
many vdevs will contain embedded slogs. The tests are not currently
upstreamed because neither is the feature, but also because they make
use of sdb to validate kernel state.

### How Has This Been Tested?
Ran ZTS locally

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
