### PR TITLE
Backport of Issue DLPX-67868 to 6.0.1.0

### DIFF
--- a/module/os/linux/zfs/zfs_znode.c
+++ b/module/os/linux/zfs/zfs_znode.c
@@ -1095,7 +1095,8 @@ again:
 		ASSERT3U(zp->z_id, ==, obj_num);
 		/*
 		 * If zp->z_unlinked is set, the znode is already marked
-		 * for deletion and should not be discovered.
+		 * for deletion and should not be discovered. Check this
+		 * after checking igrab() due to fsetxattr() & O_TMPFILE.
 		 *
 		 * If igrab() returns NULL the VFS has independently
 		 * determined the inode should be evicted and has
@@ -1110,10 +1111,11 @@ again:
 		 * need to detect the active SA hold thereby informing
 		 * the VFS that this inode should not be evicted.
 		 */
-		if (zp->z_unlinked) {
-			err = SET_ERROR(ENOENT);
-		} else if (igrab(ZTOI(zp)) == NULL) {
-			err = SET_ERROR(EAGAIN);
+		if (igrab(ZTOI(zp)) == NULL) {
+			if (zp->z_unlinked)
+				err = SET_ERROR(ENOENT);
+			else
+				err = SET_ERROR(EAGAIN);
 		} else {
 			*zpp = zp;
 			err = 0;


### PR DESCRIPTION
Internal Issue: DLPX-68284

Contains 2 commits: one that fixes the original issue, and one that fixes a regression introduced by the aforementioned commit.

Commit 1:
```
commit 41e1aa2a06f81640c3a3e1a6b12558d95887f662
Author: Heitor Alves de Siqueira <halves@canonical.com>
Date:   Fri Nov 15 14:56:05 2019 -0300

    Break out of zfs_zget early if unlinked znode

    If zp->z_unlinked is set, we're working with a znode that has been
    marked for deletion. If that's the case, we can skip the "goto again"
    loop and return ENOENT, as the znode should not be discovered.

    Reviewed-by: Richard Yao <ryao@gentoo.org>
    Reviewed-by: Matt Ahrens <mahrens@delphix.com>
    Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
    Signed-off-by: Heitor Alves de Siqueira <halves@canonical.com>
    Closes #9583
```

Commit 2:
```
Author: Mauricio Faria de Oliveira <mfo@canonical.com>
Date:   Thu Nov 21 17:24:03 2019 -0300

    Check for unlinked znodes after igrab()

    The changes in commit 41e1aa2a / PR #9583 introduced a regression on
    tmpfile_001_pos: fsetxattr() on a O_TMPFILE file descriptor started
    to fail with errno ENODATA:

        openat(AT_FDCWD, "/test", O_RDWR|O_TMPFILE, 0666) = 3
        <...>
        fsetxattr(3, "user.test", <...>, 64, 0) = -1 ENODATA

    The originally proposed change on PR #9583 is not susceptible to it,
    so just move the code/if-checks around back in that way, to fix it.

    Reviewed-by: Pavel Snajdr <snajpa@snajpa.net>
    Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
    Original-patch-by: Heitor Alves de Siqueira <halves@canonical.com>
    Signed-off-by: Mauricio Faria de Oliveira <mfo@canonical.com>
    Closes #9602
```

Testing:
ZFS compiles and loads correctly in 6.0/stage

zfs-precommit (pending) - http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5047/flowGraphTable/

ab-pre-push (pending) - http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2796/flowGraphTable/