### PR TITLE
Undo "LX-1144 Set MODULES=most when building initramfs"

### DIFF
--- a/contrib/initramfs/conf-hooks.d/zfs
+++ b/contrib/initramfs/conf-hooks.d/zfs
@@ -7,17 +7,3 @@ KEYMAP=y
 # Require the plymouth script to guarantee working video for the passphrase
 # prompting.
 FRAMEBUFFER=y
-
-# Workaround for https://bugs.launchpad.net/ubuntu/+source/initramfs-tools/+bug/1661629
-#
-# When building an initrd with MODULES=dep, which ubuntu tries to do when
-# installing kdump-tools, mkinitramfs tries to detect which modules are
-# necessary based on the hardware and filesystem, and include only those
-# moules in the image.
-#
-# However, the detection logic doesn't understand zfs on root, so building the
-# initramfs fails. As a workaround, override MODULES to get mkinitramfs to just
-# includes most modules without checking whether they are really needed. The
-# result is a larger initrd image than is strictly necessary, but at least it is
-# created successfully.
-MODULES=most


### PR DESCRIPTION
# Description

The reason why we implemented the above workaround has been fixed.
Undoing this makes the initramfs images of our kdump kernels smaller
which should help with our recent issues (DLPX-67876 and DLPX-68635).

# Results

The initramfs of the kdump kernel in our stock VM (non-debug bits)
is 92MB. kexec-ing into that with the current memory reservation
(512MB) we get the following memory statistics:
```
root@localhost:~# cat /proc/meminfo | head
MemTotal:         417276 kB
MemFree:          245144 kB
MemAvailable:     271336 kB
Buffers:             808 kB
Cached:            18792 kB
SwapCached:            0 kB
Active:            15172 kB
Inactive:          10576 kB
Active(anon):       6428 kB
Inactive(anon):      408 kB

root@localhost:~# free -h
      total  used  free  shared  buff/cache   available
Mem:   407M  132M  238M    684K         36M        264M
Swap:    0B    0B    0B
```

With this change AND debug-bits the initramfs gets to 67MB. Booting
into that kernel and looking at the same stats:
```
root@localhost:~# ls
root@localhost:~# cat /proc/meminfo | head
MemTotal:         418116 kB
MemFree:          253172 kB
MemAvailable:     278280 kB
Buffers:             808 kB
Cached:            18804 kB
SwapCached:            0 kB
Active:            14436 kB
Inactive:          10516 kB
Active(anon):       5616 kB
Inactive(anon):      404 kB

root@localhost:~# free -h
      total  used  free shared  buff/cache  available
Mem:   408M  125M  246M   680K         35M       271M
Swap:    0B    0B    0B
```
# Future Changes

This is the first out of a series of changes to the kdump kernel
and runtime that should hopefully unblock us for most cases at
least internally. It seems like with the recent changes in our
kernel and a few other changes that could be factors (disabling
-fipa-sra on ZFS), the size of the kdump initramfs has increased
introducing the recent failures. There are a few other things
that we could try on this front to make this file even lighter
and I'm still experimenting with those. Examples include:

[1] Getting rid of modules that we are sure we won't be using
    like various graphics and networking.

[2] Potentially separate DWARF info with a debug link for the
    ZFS module. Currently looking at the top offenders in terms
    of size of the initramfs of the kdump kernel, ZFS is a
    clear issue:
```
$ lsinitramfs /var/lib/kdump/initrd.img-5.3.0-40-generic | \
    sort -k 5 -n fresh_out.l | tail -n 5
-rw-r--r--   ...   4113896  lib/modules/5.3.0-40-generic/extra/spl/spl.ko
-rw-r--r--   ...   6340553  lib/modules/5.3.0-40-generic/kernel/drivers/gpu/..
-rw-r--r--   ...   8942824  lib/modules/5.3.0-40-generic/extra/lua/zlua.ko
-rw-r--r--   ...  13751120  lib/modules/5.3.0-40-generic/extra/icp/icp.ko
-rw-r--r--   ...  70813712  lib/modules/5.3.0-40-generic/extra/zfs/zfs.ko
```
If we don't really boot into the kdump kernel in single-user
mode, we won't be usin SDB on it and thus we probably don't
need that debug info on that context.

Furthermore, the size of initramfs is just one factor. There
are a few kernel parameters that we can pass to the crash kernel
boot parameters that could help with the runtime environment
in general like disabling memory statistics for cgroups and/or
disabling reservation of memory for memory-hotplugging.

# Other/Standard Testing:

ab-pre-push (pending): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3022/
zfs-precommit (pending): http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5103/