### PR TITLE
DLPX-69007 [Backport of DLPX-69006 to 6.0.2.0] SIMD: Use alloc_pages_node to force alignment

### DIFF
--- a/include/os/linux/kernel/linux/simd_x86.h
+++ b/include/os/linux/kernel/linux/simd_x86.h
@@ -135,6 +135,8 @@
  */
 #if defined(HAVE_KERNEL_FPU_INTERNAL)
 
+#include <linux/mm.h>
+
 extern union fpregs_state **zfs_kfpu_fpregs;
 
 /*
@@ -147,7 +149,8 @@ kfpu_fini(void)
 
 	for_each_possible_cpu(cpu) {
 		if (zfs_kfpu_fpregs[cpu] != NULL) {
-			kfree(zfs_kfpu_fpregs[cpu]);
+			free_pages((unsigned long)zfs_kfpu_fpregs[cpu],
+			    get_order(sizeof (union fpregs_state)));
 		}
 	}
 
@@ -157,20 +160,28 @@ kfpu_fini(void)
 static inline int
 kfpu_init(void)
 {
-	int cpu;
-
 	zfs_kfpu_fpregs = kzalloc(num_possible_cpus() *
 	    sizeof (union fpregs_state *), GFP_KERNEL);
 	if (zfs_kfpu_fpregs == NULL)
 		return (-ENOMEM);
 
+	/*
+	 * The fxsave and xsave operations require 16-/64-byte alignment of
+	 * the target memory. Since kmalloc() provides no alignment
+	 * guarantee instead use alloc_pages_node().
+	 */
+	unsigned int order = get_order(sizeof (union fpregs_state));
+	int cpu;
+
 	for_each_possible_cpu(cpu) {
-		zfs_kfpu_fpregs[cpu] = kmalloc_node(sizeof (union fpregs_state),
-		    GFP_KERNEL | __GFP_ZERO, cpu_to_node(cpu));
-		if (zfs_kfpu_fpregs[cpu] == NULL) {
+		struct page *page = alloc_pages_node(cpu_to_node(cpu),
+		    GFP_KERNEL | __GFP_ZERO, order);
+		if (page == NULL) {
 			kfpu_fini();
 			return (-ENOMEM);
 		}
+
+		zfs_kfpu_fpregs[cpu] = page_address(page);
 	}
 
 	return (0);


### PR DESCRIPTION
Clean cherry-pick from master.

http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5118/
The ZTS failure is an unrelated issue which @jwk404 is filing a bug for.
The ztest failure is also unrelated.

commit message:

fxsave and xsave require the target address to be 16-/64-byte aligned.

kmalloc(_node) does not (yet) offer such fine-grained control over
alignment[0,1], even though it does "the right thing" most of the time
for power-of-2 sizes. unfortunately, alignment is completely off when
using certain debugging or hardening features/configs, such as KASAN,
slub_debug=Z or the not-yet-upstream SLAB_CANARY.

Use alloc_pages_node() instead which allows us to allocate page-aligned
memory. Since fpregs_state is padded to a full page anyway, and this
code is only relevant for x86 which has 4k pages, this approach should
not allocate any unnecessary memory but still guarantee the needed
alignment.

0: https://lwn.net/Articles/787740/
1: https://lore.kernel.org/linux-block/20190826111627.7505-1-vbabka@suse.cz/

Reviewed-by: Tony Hutter <hutter2@llnl.gov>
Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
Closes #9608 
Closes #9674
