### PR TITLE
DLPX-69299 [Backport of DLPX-69298 to 6.0.1.1] Data corruption after DE reboot if zfs sync=standard on zvols

### DIFF
--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -96,7 +96,12 @@ unsigned int zvol_inhibit_dev = 0;
 unsigned int zvol_major = ZVOL_MAJOR;
 unsigned int zvol_threads = 32;
 unsigned int zvol_request_sync = 0;
-unsigned int zvol_sync_by_default = 0;
+/*
+ * Delphix: Make all zvol writes and discards sync unless sync=disabled
+ * is set. This is meant to avoid data corruption when exposing the zvols
+ * over iSCSI and the system reboots unexpectedly.
+ */
+unsigned int zvol_sync_by_default = 1;
 unsigned int zvol_prefetch_bytes = (128 * 1024);
 unsigned long zvol_max_discard_blocks = 16384;
 unsigned int zvol_volmode = ZFS_VOLMODE_GEOM;


### PR DESCRIPTION
### Motivation and Context
Make all zvol writes and discards sync unless sync=disabled is set. This is meant to avoid data corruption when exposing the zvols over iSCSI and the system reboots unexpectedly.
### Description
This work is split into 2 parts:
1. Adding a new tunable that, when set, makes sync=standard behave the same way as sync=always for zvols. This work can be upstreamed.
2. Enable the tunable for Delphix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3185/