### PR TITLE
DLPX-68989 [Backport of DLPX-68988 to 6.0.2.0] Don't call arc_buf_destroy on unallocated arc_buf

### DIFF
--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -935,6 +935,7 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 		blkptr_t *bp = &srdp->bp;
 		spa_t *spa =
 		    dmu_objset_spa(dscp->dsc_os);
+		arc_buf_t *abuf = NULL;
 
 		ASSERT3U(srdp->datablksz, ==, BP_GET_LSIZE(bp));
 		ASSERT3U(range->start_blkid + 1, ==, range->end_blkid);
@@ -947,7 +948,6 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 				zioflags |= ZIO_FLAG_RAW;
 			}
 
-			arc_buf_t *abuf;
 			zbookmark_phys_t zb;
 			ASSERT3U(range->start_blkid, ==, DMU_SPILL_BLKID);
 			zb.zb_objset = dmu_objset_id(dscp->dsc_os);
@@ -960,8 +960,10 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 			    zioflags, &aflags, &zb) != 0)
 				return (SET_ERROR(EIO));
 
-			err = dump_spill(dscp, bp, zb.zb_object, abuf->b_data);
-			arc_buf_destroy(abuf, &abuf);
+			err = dump_spill(dscp, bp, zb.zb_object,
+			    (abuf == NULL ? NULL : abuf->b_data));
+			if (abuf != NULL)
+				arc_buf_destroy(abuf, &abuf);
 			return (err);
 		}
 		if (send_do_embed(dscp, bp)) {
@@ -976,7 +978,6 @@ do_dump(dmu_send_cookie_t *dscp, struct send_range *range)
 		    dscp->dsc_resume_offset));
 		/* it's a level-0 block of a regular object */
 		arc_flags_t aflags = ARC_FLAG_WAIT;
-		arc_buf_t *abuf = NULL;
 		uint64_t offset;
 
 		/*


### PR DESCRIPTION
Fixes an obvious issue of calling arc_buf_destroy() on an
unallocated arc_buf.

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Matt Ahrens <matt@delphix.com>
Reviewed-by: Paul Dagnelie <pcd@delphix.com>
Signed-off-by: Chris Dunlop <chris@onthe.net.au>
Closes #9453

### Motivation and Context
Note: copied from original PR.

Fixes an obvious issue of calling arc_buf_destroy() on an unallocated arc_buf

### Description
Note: copied from original PR (with small edits).

The original issue was reported by @mattmacy in openzfs/zfs#9438 and a fix proposed.

This approach to fixing the issue is the outcome of the discussion in openzfs/zfs#9438, but it seems neither of us really know how the code is supposed to behave, thus a review from more knowledgeable contributors, hopefully including the original author @pcd1193182, is essential.

The (abuf == NULL ? etc. coding style was copied from the !split_large_blocks block further down in the same case.

### How Has This Been Tested?
ab-pre-push run: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3228/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
