### PR TITLE
Split debug info of ZFS modules to separate package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -199,5 +199,6 @@ Depends: libnvpair1linux (= ${binary:Version}),
          zfs-initramfs (= ${binary:Version}),
          zfs-test (= ${binary:Version}),
          zfs-zed (= ${binary:Version}),
-         delphix-zfs-modules
+         delphix-zfs-modules,
+         delphix-zfs-modules-dbg
 Description: Meta package for all ZFS packages installed on a Delphix appliance.

--- a/debian/control.in
+++ b/debian/control.in
@@ -199,5 +199,6 @@ Depends: libnvpair1linux (= ${binary:Version}),
          zfs-initramfs (= ${binary:Version}),
          zfs-test (= ${binary:Version}),
          zfs-zed (= ${binary:Version}),
-         delphix-zfs-modules
+         delphix-zfs-modules,
+         delphix-zfs-modules-dbg
 Description: Meta package for all ZFS packages installed on a Delphix appliance.

--- a/debian/control.modules.in
+++ b/debian/control.modules.in
@@ -58,3 +58,16 @@ Depends: zfs-modules-_KVERS_ (= ${binary:Version}),
 Description: OpenZFS kernel header files for compiling software
  to function with OpenZFS kernel modules.
 
+Package: zfs-modules-_KVERS_-dbg
+Section: contrib/debug
+Priority: extra
+Architecture: linux-any
+Provides: zfs-modules-dbg, delphix-zfs-modules-dbg
+Depends: zfs-modules-_KVERS_ (= ${binary:Version}),
+         ${misc:Depends}
+Description: Debugging symbols for OpenZFS userland libraries and tools
+ The Z file system is a pooled filesystem designed for maximum data
+ integrity, supporting data snapshots, multiple copies, and data
+ checksums.
+ .
+ This package contains the debug symbols for all ZFS-related kernel modules.

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,7 @@ endif
 non_epoch_version=$(shell echo $(KVERS) | perl -pe 's/^\d+://')
 PACKAGE=zfs
 pmodules = $(PACKAGE)-modules-$(non_epoch_version)
+pmoddbg = ${pmodules}-dbg
 pheaders = $(PACKAGE)-headers-$(non_epoch_version)
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
@@ -193,16 +194,34 @@ override_dh_binary-modules: override_dh_prep-deb-files override_dh_configure_mod
 	$(MAKE) -C $(CURDIR)/module modules
 	$(MAKE) -C $(CURDIR)/include install DESTDIR='$(CURDIR)/debian/tmp' VERSION=build
 
-	dh_install -p${pmodules} -p${pheaders}
-	dh_installdocs -p${pmodules} -p${pheaders}
-	dh_installchangelogs -p${pmodules} -p${pheaders}
-	dh_compress -p${pmodules} -p${pheaders}
-	dh_strip -p${pmodules} -p${pheaders}
-	dh_fixperms -p${pmodules} -p${pheaders}
-	dh_installdeb -p${pmodules} -p${pheaders}
-	dh_gencontrol -p${pmodules} -p${pheaders}
-	dh_md5sums -p${pmodules} -p${pheaders}
-	dh_builddeb -p${pmodules} -p${pheaders}
+	dh_install -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_installdocs -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_installchangelogs -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_compress -p${pmodules} -p${pheaders} -p${pmoddbg}
+
+	#
+	# At this point we'd like to decouple the debug info from
+	# the kernel modules into their own package using dh_strip
+	# like this:
+	#
+	# dh_strip -p${pmodules} -p${pheaders} --dbg-package=${pmoddbg}
+	#
+	# Unfortunately dh_strip doesn't work with kernel objects (or
+	# plain C objects) - only executables and libraries (static or
+	# shared). Thus we do the stripping ourselves.
+	#
+	mkdir -p $(CURDIR)/debian/${pmoddbg}/usr/lib/debug/modules/$(KVERS)/extra
+	cp -r $(CURDIR)/debian/${pmodules}/lib $(CURDIR)/debian/${pmoddbg}/usr/lib/debug
+	for module in $$(find $(CURDIR)/debian/${pmodules} -name *.ko); do \
+		strip --strip-debug $$module; \
+		objcopy --add-gnu-debuglink=$$(find $(CURDIR)/debian/${pmoddbg} -name $$(basename $$module)) $$module; \
+	done
+
+	dh_fixperms -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_installdeb -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_gencontrol -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_md5sums -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_builddeb -p${pmodules} -p${pheaders} -p${pmoddbg}
 
 debian-copyright:
 	cme update dpkg-copyright -file debian/copyright.cme


### PR DESCRIPTION
= Motivation

We've recently been hitting issues where the crash-kernel runs out
of memory while its being bootstrapped after the main kernel panicks.
We could always keep increasing the memory reserved from the crash
kernel at the expense of the memory available to main kernel. For
customers that may not be an issue, but for developer VMs generally
provisioned with 8GB of memory the impact is higher. As a result,
I've been working on making our crash kernel lighter.

= Patch Description

The DWARF info from the ZFS-related kernel modules "dwarf"s in
size the sections of these binaries that are actually needed for
them to run. This patch splits the debug info of all the ZFS
modules into a separate debian package and strips down the original
modules. This way the initramfs of the original kernel and the
crash kernel is reduced in size allowing for potential reduction
in the amount of memory needed to be reserved for the crash kernel.

= Implementation Details

When I first decided to tackle this I thought this was a
misconfiguration on our side and `dh_strip` wasn't working as
expected. After contacting the Debian folks that seem to own
the Debian packaging of ZFS for Debian, we realized that this
is a general issue and not specific to Delphix's packaging
of ZFS. `dh_strip` doesn't work with kernel modules and it was
effective a no-op. Mo Zhou (one of the aforementioned Debian
folks) suggested that the most straightforward way would be
to manually stip these modules and place them in the right
directories, and this is what I did.

Note: The decision to install the debug info under the directory
/usr/lib/debug/lib/modules was inspired by Fedora which does the
same (couldn't find anything consistent for Debian). Furthermore,
it seems like Ubuntu conventionally does the same.

References:
[1] man debhelper & manuals referenced there
[2] man strip
[3] https://sourceware.org/gdb/current/onlinedocs/gdb/Separate-Debug-Files.html
[4] https://wiki.debian.org/DebugPackage
[5] https://wiki.debian.org/AutomaticDebugPackages

= Results

Initramfs before on ESX:
```
delphix@sd-drgn:~$ ls -lh /var/lib/kdump/initrd.img-5.3.0-42-generic
-rw-r--r-- 1 root root 99M Apr  2 21:57 /var/lib/kdump/initrd.img-5.3.0-42-generic

delphix@sd-drgn:~$ lsinitramfs -l /var/lib/kdump/initrd.img-5.3.0-42-generic | sort -k 5 -n | tail -n 5
-rw-r--r--   1 root     root      6341913 Feb 28 12:40 lib/modules/5.3.0-42-generic/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko
-rw-r--r--   1 root     root      8932776 Apr  2 21:55 lib/modules/5.3.0-42-generic/extra/lua/zlua.ko
-rw-r--r--   1 root     root     13886056 Apr  2 21:55 lib/modules/5.3.0-42-generic/extra/icp/icp.ko
-rwxr-xr-x   1 root     root     14185264 Apr  2 21:55 lib/libzpool.so.2.0.0
-rw-r--r--   1 root     root     73782264 Apr  2 21:55 lib/modules/5.3.0-42-generic/extra/zfs/zfs.ko
```


Initramfs after on ESX:
```
delphix@sd-zfs-pkg:~$ ls -lh /var/lib/kdump/initrd.img-5.3.0-45-generic
-rw-r--r-- 1 root root 62M Apr 18 02:08 /var/lib/kdump/initrd.img-5.3.0-45-generic

delphix@sd-zfs-pkg:~$ lsinitramfs -l /var/lib/kdump/initrd.img-5.3.0-45-generic | sort -k 5 -n | tail -n 5
-rw-r--r--   1 root     root      2922456 Apr 18 01:33 lib/libzpool.so.2.0.0
-rw-r--r--   1 root     root      3024337 Mar 27 12:47 lib/modules/5.3.0-45-generic/kernel/drivers/gpu/drm/nouveau/nouveau.ko
-rw-r--r--   1 root     root      3161065 Mar 27 12:47 lib/modules/5.3.0-45-generic/kernel/drivers/gpu/drm/i915/i915.ko
-rw-r--r--   1 root     root      4065288 Apr 18 01:33 lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko
-rw-r--r--   1 root     root      6341585 Mar 27 12:47 lib/modules/5.3.0-45-generic/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko
```

This will cause a 37% reduction to the size of initramfs in ESX.
The reduction percentage is higher for AWS  => from 139MB (47MB
compressed) to 52MB(19MB compressed), so 62-64% reduction.

= Testing

Artifacts created by linux-pkg:
```
$ ls linux-pkg/packages/zfs/tmp/artifacts/zfs-modules-4.15.0-1063-aws*
linux-pkg/packages/zfs/tmp/artifacts/zfs-modules-4.15.0-1063-aws-dbg_0.8.0-delphix+2020.04.17.21_amd64.deb
linux-pkg/packages/zfs/tmp/artifacts/zfs-modules-4.15.0-1063-aws_0.8.0-delphix+2020.04.17.21_amd64.deb
```

Artifact content list (note the paths and sizes of *.ko files):
```
$ dpkg --contents linux-pkg/packages/zfs/tmp/artifacts/zfs-modules-4.15.0-1063-aws_0.8.0-delphix+2020.04.17.21_amd64.deb | grep .ko
-rw-r--r-- root/root     11496 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/avl/zavl.ko
-rw-r--r-- root/root    356048 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/icp/icp.ko
-rw-r--r-- root/root    220232 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/lua/zlua.ko
-rw-r--r-- root/root    107984 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/nvpair/znvpair.ko
-rw-r--r-- root/root    157480 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/spl/spl.ko
-rw-r--r-- root/root    328880 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/unicode/zunicode.ko
-rw-r--r-- root/root    114504 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/zcommon/zcommon.ko
-rw-r--r-- root/root   4049504 2020-04-17 21:41 ./lib/modules/4.15.0-1063-aws/extra/zfs/zfs.ko

$ dpkg --contents linux-pkg/packages/zfs/tmp/artifacts/zfs-modules-4.15.0-1063-aws-dbg_0.8.0-delphix+2020.04.17.21_amd64.deb | grep .ko
-rw-r--r-- root/root    241000 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/avl/zavl.ko
-rw-r--r-- root/root  12478312 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/icp/icp.ko
-rw-r--r-- root/root   8095720 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/lua/zlua.ko
-rw-r--r-- root/root   1300336 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/nvpair/znvpair.ko
-rw-r--r-- root/root   4055432 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/spl/spl.ko
-rw-r--r-- root/root   1064112 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/unicode/zunicode.ko
-rw-r--r-- root/root   3977680 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/zcommon/zcommon.ko
-rw-r--r-- root/root  65634856 2020-04-17 21:41 ./usr/lib/debug/lib/modules/4.15.0-1063-aws/extra/zfs/zfs.ko
```

ab-pre-push links:
see - https://github.com/delphix/delphix-kernel/pull/12

Ensure everything is installed in a VM created from the above pre-push:
```
delphix@sd-zfs-pkg:~$ apt search zfs-modules-5.3.0-45-generic
Sorting... Done
Full Text Search... Done
zfs-modules-5.3.0-45-generic/now 0.8.0-delphix+2020.04.18.01 amd64 [installed,local]
  OpenZFS filesystem kernel modules for Linux (kernel 5.3.0-45-generic)

zfs-modules-5.3.0-45-generic-dbg/now 0.8.0-delphix+2020.04.18.01 amd64 [installed,local]
  Debugging symbols for OpenZFS userland libraries and tools

delphix@sd-zfs-pkg:~$ dpkg -L zfs-modules-5.3.0-45-generic-dbg
/.
/usr
/usr/lib
/usr/lib/debug
/usr/lib/debug/lib
/usr/lib/debug/lib/modules
/usr/lib/debug/lib/modules/5.3.0-45-generic
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/avl
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/avl/zavl.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/icp
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/icp/icp.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/lua
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/lua/zlua.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/nvpair
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/nvpair/znvpair.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/spl
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/spl/spl.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/unicode
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/unicode/zunicode.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zcommon
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zcommon/zcommon.ko
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zfs
/usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko
/usr/lib/debug/modules
/usr/lib/debug/modules/5.3.0-45-generic
/usr/lib/debug/modules/5.3.0-45-generic/extra
/usr/share
/usr/share/doc
/usr/share/doc/zfs-modules-5.3.0-45-generic-dbg
/usr/share/doc/zfs-modules-5.3.0-45-generic-dbg/changelog.Debian.gz
/usr/share/doc/zfs-modules-5.3.0-45-generic-dbg/copyright
```

Ensure that the binaries are connected with the debuglink:
```
delphix@sd-zfs-pkg:~$ ls -lh /lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko
-rw-r--r-- 1 root root 3.9M Apr 18 01:33 /lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko

delphix@sd-zfs-pkg:~$ ls -lh /usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko
-rw-r--r-- 1 root root 68M Apr 18 01:33 /usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko

delphix@sd-zfs-pkg:~$ readelf -S /lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko | grep debug_info
delphix@sd-zfs-pkg:~$ readelf -S /usr/lib/debug/lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko | grep debug_info
  [51] .debug_info       PROGBITS         0000000000000000  002082dc
  [52] .rela.debug_info  RELA             0000000000000000  0266de30

delphix@sd-zfs-pkg:~$ readelf -x.gnu_debuglink /lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko

Hex dump of section '.gnu_debuglink':
  0x00000000 7a66732e 6b6f0000 facaadd7          zfs.ko......
```

Ensure that SDB and crash-python still work:
```
delphix@sd-zfs-pkg:~$  sudo sdb
sdb> spa
ADDR               NAME
------------------------------------------------------------
0xffff8c2616588000 rpool
^D

delphix@sd-zfs-pkg:~$ sudo crash-kcore.sh
...<cropped>...
add symbol table from file "/usr/lib/debug/boot/vmlinux-5.3.0-45-generic" with all sections offset by 0x24800000
Slick Debugger (sdb) initializing...
Loading tasks....... done. (443 tasks total)
Loading modules for 5.3.0-45-genericLoading /lib/modules/5.3.0-45-generic/kernel/net/connstat/connstat.ko at 0xffffffffc0ea1000
...<cropped>...
Loading /lib/modules/5.3.0-45-generic/extra/zfs/zfs.ko at 0xffffffffc0774000
Loading /lib/modules/5.3.0-45-generic/extra/unicode/zunicode.ko at 0xffffffffc0722000
Loading /lib/modules/5.3.0-45-generic/extra/lua/zlua.ko at 0xffffffffc06f3000
Loading /lib/modules/5.3.0-45-generic/extra/avl/zavl.ko at 0xffffffffc036d000
...<cropped>...
(gdb) spa
ADDR           NAME
------------------------------------------------------------
0xffff8c2616588000 rpool
```

I also wanted to make sure that we can still access these files from the
crash kernel if we boot into single-user mode. We can even run sdb as in
the original kernel:
```
You are in rescue mode. After logging in, type "journalctl -xb" to view
system logs, "systemctl reboot" to reboot, "systemctl default" or "exit"
to boot into default mode.
Give root password for maintenance
(or press Control-D to continue):
root@localhost:~# sdb
sdb> spa
ADDR               NAME
------------------------------------------------------------
0xffff99c16988c000 rpool
```

Finally I made sure to capture a normal crash-dump and analyze it as before:
```
delphix@sd-zfs-pkg:/var/crash/202004181853$ sudo sdb /usr/lib/debug/boot/vmlinux-5.3.0-45-generic dump.202004181853
sdb> spa
ADDR               NAME
------------------------------------------------------------
0xffff899b558bc000 rpool
```

= Future Work

[1] Add modifications to zfs-load so the same thing happens for
developers iterating on ZFS changes internally.

[2] Continue making the crash-kernel lighter by disabling unecessary
subsystems and functionality that consume memory (e.g. memory
hotplugging, systemd cgroup memory statistic metadata, etc..).

[3] Reach out to our contacts from LKDC for further improvements.
