### PR TITLE
Backport: Split debug info of ZFS modules to separate package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -199,5 +199,6 @@ Depends: libnvpair1linux (= ${binary:Version}),
          zfs-initramfs (= ${binary:Version}),
          zfs-test (= ${binary:Version}),
          zfs-zed (= ${binary:Version}),
-         delphix-zfs-modules
+         delphix-zfs-modules,
+         delphix-zfs-modules-dbg
 Description: Meta package for all ZFS packages installed on a Delphix appliance.

--- a/debian/control.in
+++ b/debian/control.in
@@ -199,5 +199,6 @@ Depends: libnvpair1linux (= ${binary:Version}),
          zfs-initramfs (= ${binary:Version}),
          zfs-test (= ${binary:Version}),
          zfs-zed (= ${binary:Version}),
-         delphix-zfs-modules
+         delphix-zfs-modules,
+         delphix-zfs-modules-dbg
 Description: Meta package for all ZFS packages installed on a Delphix appliance.

--- a/debian/control.modules.in
+++ b/debian/control.modules.in
@@ -58,3 +58,16 @@ Depends: zfs-modules-_KVERS_ (= ${binary:Version}),
 Description: OpenZFS kernel header files for compiling software
  to function with OpenZFS kernel modules.
 
+Package: zfs-modules-_KVERS_-dbg
+Section: contrib/debug
+Priority: extra
+Architecture: linux-any
+Provides: zfs-modules-dbg, delphix-zfs-modules-dbg
+Depends: zfs-modules-_KVERS_ (= ${binary:Version}),
+         ${misc:Depends}
+Description: Debugging symbols for OpenZFS userland libraries and tools
+ The Z file system is a pooled filesystem designed for maximum data
+ integrity, supporting data snapshots, multiple copies, and data
+ checksums.
+ .
+ This package contains the debug symbols for all ZFS-related kernel modules.

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,7 @@ endif
 non_epoch_version=$(shell echo $(KVERS) | perl -pe 's/^\d+://')
 PACKAGE=zfs
 pmodules = $(PACKAGE)-modules-$(non_epoch_version)
+pmoddbg = ${pmodules}-dbg
 pheaders = $(PACKAGE)-headers-$(non_epoch_version)
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
@@ -193,16 +194,34 @@ override_dh_binary-modules: override_dh_prep-deb-files override_dh_configure_mod
 	$(MAKE) -C $(CURDIR)/module modules
 	$(MAKE) -C $(CURDIR)/include install DESTDIR='$(CURDIR)/debian/tmp' VERSION=build
 
-	dh_install -p${pmodules} -p${pheaders}
-	dh_installdocs -p${pmodules} -p${pheaders}
-	dh_installchangelogs -p${pmodules} -p${pheaders}
-	dh_compress -p${pmodules} -p${pheaders}
-	dh_strip -p${pmodules} -p${pheaders}
-	dh_fixperms -p${pmodules} -p${pheaders}
-	dh_installdeb -p${pmodules} -p${pheaders}
-	dh_gencontrol -p${pmodules} -p${pheaders}
-	dh_md5sums -p${pmodules} -p${pheaders}
-	dh_builddeb -p${pmodules} -p${pheaders}
+	dh_install -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_installdocs -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_installchangelogs -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_compress -p${pmodules} -p${pheaders} -p${pmoddbg}
+
+	#
+	# At this point we'd like to decouple the debug info from
+	# the kernel modules into their own package using dh_strip
+	# like this:
+	#
+	# dh_strip -p${pmodules} -p${pheaders} --dbg-package=${pmoddbg}
+	#
+	# Unfortunately dh_strip doesn't work with kernel objects (or
+	# plain C objects) - only executables and libraries (static or
+	# shared). Thus we do the stripping ourselves.
+	#
+	mkdir -p $(CURDIR)/debian/${pmoddbg}/usr/lib/debug/modules/$(KVERS)/extra
+	cp -r $(CURDIR)/debian/${pmodules}/lib $(CURDIR)/debian/${pmoddbg}/usr/lib/debug
+	for module in $$(find $(CURDIR)/debian/${pmodules} -name *.ko); do \
+		strip --strip-debug $$module; \
+		objcopy --add-gnu-debuglink=$$(find $(CURDIR)/debian/${pmoddbg} -name $$(basename $$module)) $$module; \
+	done
+
+	dh_fixperms -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_installdeb -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_gencontrol -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_md5sums -p${pmodules} -p${pheaders} -p${pmoddbg}
+	dh_builddeb -p${pmodules} -p${pheaders} -p${pmoddbg}
 
 debian-copyright:
 	cme update dpkg-copyright -file debian/copyright.cme


### PR DESCRIPTION
Original: https://github.com/delphix/zfs/pull/154

Pair commit needed in delphix-kernel: https://github.com/delphix/delphix-kernel/pull/13

Testing:
Did the exact same testing with original review for 6.0 - current VM holding all the changes is sd-60-split.dcenter