### PR TITLE
Revert "Update skc_obj_alloc for spl kmem caches that are backed by Linux

### DIFF
--- a/module/os/linux/spl/spl-kmem-cache.c
+++ b/module/os/linux/spl/spl-kmem-cache.c
@@ -1453,17 +1453,6 @@ spl_kmem_cache_alloc(spl_kmem_cache_t *skc, int flags)
 			obj = kmem_cache_alloc(slc, kmem_flags_convert(flags));
 		} while ((obj == NULL) && !(flags & KM_NOSLEEP));
 
-		if (obj != NULL) {
-			/*
-			 * Even though we leave everything up to the
-			 * underlying cache we still keep track of
-			 * how many objects we've allocated in it for
-			 * better debuggability.
-			 */
-			spin_lock(&skc->skc_lock);
-			skc->skc_obj_alloc++;
-			spin_unlock(&skc->skc_lock);
-		}
 		goto ret;
 	}
 
@@ -1537,9 +1526,6 @@ spl_kmem_cache_free(spl_kmem_cache_t *skc, void *obj)
 	 */
 	if (skc->skc_flags & KMC_SLAB) {
 		kmem_cache_free(skc->skc_linux_cache, obj);
-		spin_lock(&skc->skc_lock);
-		skc->skc_obj_alloc--;
-		spin_unlock(&skc->skc_lock);
 		return;
 	}
 

--- a/module/os/linux/spl/spl-proc.c
+++ b/module/os/linux/spl/spl-proc.c
@@ -437,29 +437,11 @@ slab_seq_show(struct seq_file *f, void *p)
 
 	ASSERT(skc->skc_magic == SKC_MAGIC);
 
-	if (skc->skc_flags & KMC_SLAB) {
-		/*
-		 * This cache is backed by a generic Linux kmem cache which
-		 * has its own accounting. For these caches we only track
-		 * the number of active allocated objects that exist within
-		 * the underlying Linux slabs. For the overall statistics of
-		 * the underlying Linux cache please refer to /proc/slabinfo.
-		 */
-		spin_lock(&skc->skc_lock);
-		seq_printf(f, "%-36s  ", skc->skc_name);
-		seq_printf(f, "0x%05lx %9s %9lu %8s %8u  "
-		    "%5s %5s %5s  %5s %5lu %5s  %5s %5s %5s\n",
-		    (long unsigned)skc->skc_flags,
-		    "-",
-		    (long unsigned)(skc->skc_obj_size * skc->skc_obj_alloc),
-		    "-",
-		    (unsigned)skc->skc_obj_size,
-		    "-", "-", "-", "-",
-		    (long unsigned)skc->skc_obj_alloc,
-		    "-", "-", "-", "-");
-		spin_unlock(&skc->skc_lock);
+	/*
+	 * Backed by Linux slab see /proc/slabinfo.
+	 */
+	if (skc->skc_flags & KMC_SLAB)
 		return (0);
-	}
 
 	spin_lock(&skc->skc_lock);
 	seq_printf(f, "%-36s  ", skc->skc_name);
@@ -479,7 +461,9 @@ slab_seq_show(struct seq_file *f, void *p)
 	    (long unsigned)skc->skc_obj_deadlock,
 	    (long unsigned)skc->skc_obj_emergency,
 	    (long unsigned)skc->skc_obj_emergency_max);
+
 	spin_unlock(&skc->skc_lock);
+
 	return (0);
 }
 


### PR DESCRIPTION
This reverts commit f75dea29b3ac9a4d63017e6c8fc41b4896a8bc22.

We've hit a performance regression in this commit where running the
ZFS performance suite we've observed 1~8% slowdown. As the commit
was made purely for debugging purposes in a code path that doesn't
change often, the revert is pretty low-risk.

ran ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3392/flowGraphTable/
(dx-test is known failure)

ran zfs-make and load on a VM and ensured that the change is gone by running `spl_kmem_caches` on SDB