### PR TITLE
Running `make install` should split debug info

### DIFF
--- a/module/Makefile.in
+++ b/module/Makefile.in
@@ -10,6 +10,8 @@ obj-m += zfs/
 obj-m += os/linux/zfs/
 
 INSTALL_MOD_DIR ?= extra
+LINUX_MOD_DIR ?= /lib/modules/@LINUX_VERSION@
+LINUX_DEBUG_MOD_DIR ?= /usr/lib/debug/$(LINUX_MOD_DIR)
 
 ZFS_MODULE_CFLAGS += -std=gnu99 -Wno-declaration-after-statement
 ZFS_MODULE_CFLAGS += @KERNEL_DEBUG_CFLAGS@  @NO_FORMAT_ZERO_LENGTH@
@@ -77,6 +79,15 @@ modules_install-Linux:
 	if [ -n "$(DESTDIR)" ]; then \
 		find $$kmoddir -name 'modules.*' | xargs $(RM); \
 	fi
+	@# Delphix-specific: split debug info
+	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)$(LINUX_MOD_DIR); \
+	debugdir=$(DESTDIR)$(INSTALL_MOD_PATH)$(LINUX_DEBUG_MOD_DIR); \
+	for module in $$(find . -name *.ko); do \
+		mkdir -p $$debugdir/$(INSTALL_MOD_DIR)/$$(dirname $$module); \
+		cp $$kmoddir/$(INSTALL_MOD_DIR)/$$module $$debugdir/$(INSTALL_MOD_DIR)/$$module; \
+		strip --strip-debug $$kmoddir/$(INSTALL_MOD_DIR)/$$module; \
+		objcopy --add-gnu-debuglink=$$debugdir/$(INSTALL_MOD_DIR)/$$module $$kmoddir/$(INSTALL_MOD_DIR)/$$module; \
+	done
 	sysmap=$(DESTDIR)$(INSTALL_MOD_PATH)/boot/System.map-@LINUX_VERSION@; \
 	if [ -f $$sysmap ]; then \
 		depmod -ae -F $$sysmap @LINUX_VERSION@; \
@@ -118,9 +129,11 @@ modules_install: modules_install-@ac_system@
 
 modules_uninstall-Linux:
 	@# Uninstall the kernel modules
-	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@
+	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)$(LINUX_MOD_DIR); \
+	debugdir=$(DESTDIR)$(INSTALL_MOD_PATH)$(LINUX_DEBUG_MOD_DIR); \
 	list='$(obj-m)'; for objdir in $$list; do \
 		$(RM) -R $$kmoddir/$(INSTALL_MOD_DIR)/$$objdir; \
+		$(RM) -fR $$debugdir/$(INSTALL_MOD_DIR)/$$objdir; \
 	done
 
 modules_uninstall-FreeBSD:


### PR DESCRIPTION
= Problem

Even though the debug info is split from the kernel modules
when they are packaged for the product, developers iterating
using git-zfs-{make,load} have to manually split the DWARF
info themselves and then recreate the crash kernel.

= Patch

This patch changes the modules_install target of the modules
Makefile that runs every time we do `make install` from the
root of the repo (git-zfs-load does that too). The code added
to the target is very similar to the one used in debian/rules
that provides the same functionality. Unfortunately that code
will have to stay duplicated unless we decide to do a major
refactoring in the debian directory where we can issen a
single `make install` command for all packages (userland,
headers, and modules) and everything will be placed and
packaged in its respective debian package with minimal help
from .install files used by dh_install.

= Testing

AWS ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3430/

ESX ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3431/

* The following tests are done with the VM image generated
by the AWS pre-push above

Sanity check before we ran git-zfs-{make,load}:
```
$ ls -lh /var/lib/kdump/initrd.img-5.3.0-1017-aws /lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko /usr/lib/debug//lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r-- 1 root root 3.9M May  8 05:38 /lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r-- 1 root root  68M May  8 05:38 /usr/lib/debug//lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r-- 1 root root  33M May  8 06:48 /var/lib/kdump/initrd.img-5.3.0-1017-aws

$ lsinitramfs -l /var/lib/kdump/initrd.img-5.3.0-1017-aws | sort -k 5 -n | tail -n 5
-rw-r--r--   1 root     root      2917216 Nov 12 16:58 usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
-rw-r--r--   1 root     root      2922456 May  8 05:38 lib/libzpool.so.2.0.0
-rw-r--r--   1 root     root      3162849 Apr  8 13:56 lib/modules/5.3.0-1017-aws/kernel/drivers/gpu/drm/i915/i915.ko
-rw-r--r--   1 root     root      4058968 May  8 05:38 lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r--   1 root     root      6344097 Apr  8 13:56 lib/modules/5.3.0-1017-aws/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko

$ sudo sdb -e 'spa'
ADDR               NAME
------------------------------------------------------------
0xffff93a454d74000 rpool
```

After running git-zfs-make and git-zfs-load:
```
$ ls -lh /var/lib/kdump/initrd.img-5.3.0-1017-aws /lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko /usr/lib/debug//lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r-- 1 root root 5.3M May  8 16:28 /lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r-- 1 root root  71M May  8 16:28 /usr/lib/debug//lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r-- 1 root root  39M May  8 16:29 /var/lib/kdump/initrd.img-5.3.0-1017-aws

$ lsinitramfs -l /var/lib/kdump/initrd.img-5.3.0-1017-aws | sort -k 5 -n | tail -n 5
-rw-r--r--   1 root     root      2917216 Nov 12 16:58 usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
-rw-r--r--   1 root     root      3162849 Apr  8 13:56 lib/modules/5.3.0-1017-aws/kernel/drivers/gpu/drm/i915/i915.ko
-rw-r--r--   1 root     root      5540560 May  8 16:28 lib/modules/5.3.0-1017-aws/extra/zfs/zfs.ko
-rw-r--r--   1 root     root      6344097 Apr  8 13:56 lib/modules/5.3.0-1017-aws/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko
-rwxr-xr-x   1 root     root     14236280 May  8 16:28 lib/libzpool.so.2.0.0

$ sudo sdb -e 'spa'
ADDR               NAME
------------------------------------------------------------
0xffff9847d34f4000 rpool
```
