### PR TITLE
DLPX-69750 PANIC in zfs_ioc_objset_stats_impl after redacted receive from illumos

### DIFF
--- a/lib/libzfs_core/libzfs_core.c
+++ b/lib/libzfs_core/libzfs_core.c
@@ -997,7 +997,7 @@ lzc_receive_resumable_illumos(const char *snapname, nvlist_t *props,
     const char *origin, boolean_t force, boolean_t raw, int fd)
 {
 	return (recv_impl(snapname, props, NULL, NULL, 0, origin, force,
-	    B_TRUE, raw, B_FALSE, fd, NULL, NULL, NULL, NULL));
+	    B_TRUE, raw, B_TRUE, fd, NULL, NULL, NULL, NULL));
 }
 
 /*


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.delphix.com/browse/DLPX-69750

### Description
<!--- Describe your changes in detail -->
The commit that cherry-picked the upstream commit "Remove deduplicated
send/receive code" changed `lzc_receive_resumable_illumos()` to pass
`illumos=B_FALSE` instead of `illumos=B_TRUE`.  This breaks SDD
(redacted receive) from 5.3 to master.

Introduced by: e87eb86210f5c5d991634262f6b683b3a3a4d830

This problem is compounded by https://github.com/openzfs/zfs/pull/10320 "fix error handling in receive_writer_thread()", which causes this to result in incorrect on-disk state leading to this panic.  With that error handling fixed, the test fails, rather than panicking.  With both fixes, the test passes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

running sdd tests

