### PR TITLE
DLPX-69914 disable automatic scrubs

### DIFF
--- a/debian/zfsutils-linux.cron.d
+++ b/debian/zfsutils-linux.cron.d
@@ -1,4 +1,4 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # Scrub the second Sunday of every month.
-24 0 8-14 * * root [ $(date +\%w) -eq 0 ] && [ -x /usr/lib/zfs-linux/scrub ] && /usr/lib/zfs-linux/scrub
+# 24 0 8-14 * * root [ $(date +\%w) -eq 0 ] && [ -x /usr/lib/zfs-linux/scrub ] && /usr/lib/zfs-linux/scrub


### PR DESCRIPTION
For our appliance, I'm proposing that we just comment out the cron entry to prevent automatic scrubs from being kicked off. Other possible solutions:

- remove the cron file from package
- update the scrub script to exclude some set of pools

I don't have a strong opinion one way or another so I've chosen the simplest approach.