### PR TITLE
Fix error handling in receive_writer_thread()

### DIFF
--- a/module/zfs/dmu_recv.c
+++ b/module/zfs/dmu_recv.c
@@ -2700,7 +2700,8 @@ receive_writer_thread(void *arg)
 		 * free it.
 		 */
 		if (err != EAGAIN) {
-			rwa->err = err;
+			if (rwa->err == 0)
+				rwa->err = err;
 			kmem_free(rrd, sizeof (*rrd));
 		}
 	}


### PR DESCRIPTION
This is essentially a follow-on to https://github.com/delphix/zfs/pull/159.  It is a clean cherry-pick of upstream's https://github.com/openzfs/zfs/pull/10320.

testing (in progress): http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5224/

If `receive_writer_thread()` gets an error from `receive_process_record()`,
it should be saved in `rwa->err` so that we will stop processing records,
and the main thread will notice that the receive has failed.

When an error is first encountered, this happens correctly.  However, if
there are more records to dequeue, the next time through the loop we
will reset `rwa->err` to zero, allowing us to try to process the
following record (2 after the failed record).  Depending on what types
of records remain, we may incorrectly complete the receive
"successfully", but without actually having processed all the records.

The fix is to only set `rwa->err` if we got a *non-zero* error.

This bug was introduced by #10099 "Improve zfs receive performance by
batching writes".

Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
Reviewed-by: Paul Dagnelie <pcd@delphix.com>
Signed-off-by: Matthew Ahrens <mahrens@delphix.com>
Closes #10320

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->
