### PR TITLE
Fix merge conflict

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS  = zfs zpool zdb zhack zinject zstream zstreamdump ztest
-SUBDIRS += fsck_zfs vdev_id raidz_test
+SUBDIRS += fsck_zfs vdev_id raidz_test zfs_ids_to_path
 
 if USING_PYTHON
 SUBDIRS += arcstat arc_summary dbufstat

--- a/cmd/zfs_ids_to_path/zfs_ids_to_path.c
+++ b/cmd/zfs_ids_to_path/zfs_ids_to_path.c
@@ -35,7 +35,7 @@ libzfs_handle_t *g_zfs;
 void
 usage(int err)
 {
-	fprintf(stderr, "Usage: ./os_id_to_name <pool> <objset id> "
+	fprintf(stderr, "Usage: [-v] zfs_ids_to_path <pool> <objset id> "
 	    "<object id>\n");
 	exit(err);
 }
@@ -43,18 +43,30 @@ usage(int err)
 int
 main(int argc, char **argv)
 {
-	if (argc != 4) {
+	boolean_t verbose = B_FALSE;
+	char c;
+	while ((c = getopt(argc, argv, "v")) != -1) {
+		switch (c) {
+		case 'v':
+			verbose = B_TRUE;
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc != 3) {
 		(void) fprintf(stderr, "Incorrect number of arguments: %d\n",
 		    argc);
 		usage(1);
 	}
 
 	uint64_t objset, object;
-	if (sscanf(argv[2], "%lu", &objset) != 1) {
+	if (sscanf(argv[1], "%llu", (u_longlong_t *)&objset) != 1) {
 		(void) fprintf(stderr, "Invalid objset id: %s\n", argv[2]);
 		usage(2);
 	}
-	if (sscanf(argv[3], "%lu", &object) != 1) {
+	if (sscanf(argv[2], "%llu", (u_longlong_t *)&object) != 1) {
 		(void) fprintf(stderr, "Invalid object id: %s\n", argv[3]);
 		usage(3);
 	}
@@ -62,7 +74,7 @@ main(int argc, char **argv)
 		(void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
 		return (4);
 	}
-	zpool_handle_t *pool = zpool_open(g_zfs, argv[1]);
+	zpool_handle_t *pool = zpool_open(g_zfs, argv[0]);
 	if (pool == NULL) {
 		fprintf(stderr, "Could not open pool %s\n", argv[1]);
 		libzfs_fini(g_zfs);
@@ -70,7 +82,13 @@ main(int argc, char **argv)
 	}
 
 	char pathname[PATH_MAX * 2];
-	zpool_obj_to_path(pool, objset, object, pathname, PATH_MAX * 2);
+	if (verbose) {
+		zpool_obj_to_path_ds(pool, objset, object, pathname,
+		    sizeof (pathname));
+	} else {
+		zpool_obj_to_path(pool, objset, object, pathname,
+		    sizeof (pathname));
+	}
 	printf("%s\n", pathname);
 	zpool_close(pool);
 	libzfs_fini(g_zfs);

--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,7 @@ AC_CONFIG_FILES([
 	tests/zfs-tests/tests/functional/cli_root/zfs_destroy/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_diff/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_get/Makefile
+	tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_inherit/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_load-key/Makefile
 	tests/zfs-tests/tests/functional/cli_root/zfs_mount/Makefile

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -75,6 +75,7 @@ usr/share/man/man8/zfs-unmount.8
 usr/share/man/man8/zfs-upgrade.8
 usr/share/man/man8/zfs-userspace.8
 usr/share/man/man8/zfs-wait.8
+usr/share/man/man8/zfs_ids_to_path.8
 usr/share/man/man8/zfsconcepts.8
 usr/share/man/man8/zfsprops.8
 usr/share/man/man8/zdb.8

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -441,8 +441,10 @@ extern int zpool_events_next(libzfs_handle_t *, nvlist_t **, int *, unsigned,
     int);
 extern int zpool_events_clear(libzfs_handle_t *, int *);
 extern int zpool_events_seek(libzfs_handle_t *, uint64_t, int);
+extern void zpool_obj_to_path_ds(zpool_handle_t *, uint64_t, uint64_t, char *,
+    size_t);
 extern void zpool_obj_to_path(zpool_handle_t *, uint64_t, uint64_t, char *,
-    size_t len);
+    size_t);
 extern int zfs_ioctl(libzfs_handle_t *, int, struct zfs_cmd *);
 extern int zpool_get_physpath(zpool_handle_t *, char *, size_t);
 extern void zpool_explain_recover(libzfs_handle_t *, const char *, int,

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -42,6 +42,7 @@ dist_man_MANS = \
 	zfs-upgrade.8 \
 	zfs-userspace.8 \
 	zfs-wait.8 \
+	zfs_ids_to_path.8 \
 	zgenhostid.8 \
 	zinject.8 \
 	zpool.8 \

--- a/man/man8/zfs_ids_to_path.8
+++ b/man/man8/zfs_ids_to_path.8
@@ -1,0 +1,50 @@
+.\"
+.\" CDDL HEADER START
+.\"
+.\" The contents of this file are subject to the terms of the
+.\" Common Development and Distribution License (the "License").
+.\" You may not use this file except in compliance with the License.
+.\"
+.\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+.\" or http://www.opensolaris.org/os/licensing.
+.\" See the License for the specific language governing permissions
+.\" and limitations under the License.
+.\"
+.\" When distributing Covered Code, include this CDDL HEADER in each
+.\" file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+.\" If applicable, add the following below this CDDL HEADER, with the
+.\" fields enclosed by brackets "[]" replaced with your own identifying
+.\" information: Portions Copyright [yyyy] [name of copyright owner]
+.\"
+.\" CDDL HEADER END
+.\"
+.\"
+.\" Copyright (c) 2020 by Delphix. All rights reserved.
+.Dd April 17, 2020
+.Dt ZFS_IDS_TO_PATH 8
+.Os Linux
+.Sh NAME
+.Nm zfs_ids_to_path
+.Nd convert objset and object ids to names and paths
+.Sh SYNOPSIS
+.Nm
+.Op Fl v
+.Ar pool
+.Ar objset id
+.Ar object id
+.Nm
+.Sh DESCRIPTION
+.Pp
+.LP
+The
+.Sy zfs_ids_to_path
+utility converts a provided objset and object id into a path to the file that
+those ids refer to.
+.Bl -tag -width "-D"
+.It Fl v
+Verbose.
+Print the dataset name and the file path within the dataset separately. This
+will work correctly even if the dataset is not mounted.
+.Sh SEE ALSO
+.Xr zfs 8 ,
+.Xr zdb 8

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -169,6 +169,10 @@ tests = ['zfs_get_001_pos', 'zfs_get_002_pos', 'zfs_get_003_pos',
     'zfs_get_008_pos', 'zfs_get_009_pos', 'zfs_get_010_neg']
 tags = ['functional', 'cli_root', 'zfs_get']
 
+[tests/functional/cli_root/zfs_ids_to_path]
+tests = ['zfs_ids_to_path_001_pos']
+tags = ['functional', 'cli_root', 'zfs_ids_to_path']
+
 [tests/functional/cli_root/zfs_inherit]
 tests = ['zfs_inherit_001_neg', 'zfs_inherit_002_neg', 'zfs_inherit_003_pos',
     'zfs_inherit_mountpoint']

--- a/tests/zfs-tests/include/commands.cfg
+++ b/tests/zfs-tests/include/commands.cfg
@@ -183,7 +183,8 @@ export ZFS_FILES='zdb
     zed
     zgenhostid
     zstream
-    zstreamdump'
+    zstreamdump
+    zfs_ids_to_path'
 
 export ZFSTEST_FILES='btree_test
     chg_usr_exec

--- a/tests/zfs-tests/tests/functional/cli_root/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/Makefile.am
@@ -13,6 +13,7 @@ SUBDIRS = \
 	zfs_destroy \
 	zfs_diff \
 	zfs_get \
+	zfs_ids_to_path \
 	zfs_inherit \
 	zfs_load-key \
 	zfs_mount \

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/Makefile.am
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/Makefile.am
@@ -1,0 +1,5 @@
+pkgdatadir = $(datadir)/@PACKAGE@/zfs-tests/tests/functional/cli_root/zfs_ids_to_path
+dist_pkgdata_SCRIPTS = \
+	setup.ksh \
+	cleanup.ksh \
+	zfs_ids_to_path_001_pos.ksh

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/cleanup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/cleanup.ksh
@@ -1,0 +1,29 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/setup.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/setup.ksh
@@ -1,0 +1,31 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+verify_runnable "global"
+
+default_setup $DISKS

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/zfs_ids_to_path_001_pos.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_ids_to_path/zfs_ids_to_path_001_pos.ksh
@@ -1,0 +1,96 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION: Identify the objset id and the object id of a file in a
+# filesystem, and verify that zfs_ids_to_path behaves correctly with them.
+#
+# STRATEGY:
+# 1. Create a dateset
+# 2. Makes files in the dataset
+# 3. Verify that zfs_ids_to_path outputs the correct format for each one
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	destroy_dataset $TESTPOOL/$TESTFS
+	zfs create -o mountpoint=$TESTDIR $TESTPOOL/$TESTFS
+}
+
+function test_one
+{
+	typeset ds_id="$1"
+	typeset ds_path="$2"
+	typeset file_path="$3"
+
+	typeset mntpnt=$(get_prop mountpoint $ds_path)
+	typeset file_id=$(ls -i /$mntpnt/$file_path | sed 's/ .*//')
+	typeset output=$(zfs_ids_to_path $TESTPOOL $ds_id $file_id)
+	[[ "$output" == "$mntpnt/$file_path" ]] || \
+		log_fail "Incorrect output for non-verbose while mounted: $output"
+	output=$(zfs_ids_to_path -v $TESTPOOL $ds_id $file_id)
+	[[ "$output" == "$ds_path:/$file_path" ]] || \
+		log_fail "Incorrect output for verbose while mounted: $output"
+	log_must zfs unmount $ds_path
+	output=$(zfs_ids_to_path $TESTPOOL $ds_id $file_id)
+	[[ "$output" == "$ds_path:/$file_path" ]] || \
+		log_fail "Incorrect output for non-verbose while unmounted: $output"
+	output=$(zfs_ids_to_path -v $TESTPOOL $ds_id $file_id)
+	[[ "$output" == "$ds_path:/$file_path" ]] || \
+		log_fail "Incorrect output for verbose while unmounted: $output"
+	log_must zfs mount $ds_path
+}
+
+log_onexit cleanup
+
+typeset BASE=$TESTPOOL/$TESTFS
+typeset TESTFILE1=f1
+typeset TESTDIR1=d1
+typeset TESTFILE2=d1/f2
+typeset TESTDIR2=d1/d2
+typeset TESTFILE3=d1/d2/f3
+typeset TESTFILE4=d1/d2/f4
+
+typeset mntpnt=$(get_prop mountpoint $BASE)
+
+log_must touch /$mntpnt/$TESTFILE1
+log_must mkdir /$mntpnt/$TESTDIR1
+log_must touch /$mntpnt/$TESTFILE2
+log_must mkdir /$mntpnt/$TESTDIR2
+log_must touch /$mntpnt/$TESTFILE3
+log_must touch /$mntpnt/$TESTFILE4
+
+typeset ds_id=$(zdb $BASE | grep "^Dataset" | sed 's/.* ID \([0-9]*\).*/\1/')
+test_one $ds_id $BASE $TESTFILE1
+test_one $ds_id $BASE $TESTFILE2
+test_one $ds_id $BASE $TESTFILE3
+test_one $ds_id $BASE $TESTFILE4
+
+log_pass "zfs_ids_to_path displayed correctly"


### PR DESCRIPTION
= Merge Conflict
Job that hit the merge conflict: http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/zfs/job/update/968/

```
10:23:28  CONFLICT (add/add): Merge conflict in cmd/zfs_ids_to_path/zfs_ids_to_path.c
10:23:28  Auto-merging cmd/Makefile.am
10:23:28  Automatic merge failed; fix conflicts and then commit the result.
10:23:28  git merge failed
10:23:28  Running: git merge --abort
10:23:28  Error: failed command 'merge_with_upstream'
10:23:28  Error: Failed merge with upstream for zfs
10:23:28  Error: buildpkg.sh failed.
```

= Diff
```diff
--- a/cmd/zfs_ids_to_path/zfs_ids_to_path.c
+++ b/cmd/zfs_ids_to_path/zfs_ids_to_path.c
@@ -35,7 +35,7 @@ libzfs_handle_t *g_zfs;
 void
 usage(int err)
 {
-       fprintf(stderr, "Usage: ./os_id_to_name <pool> <objset id> "
+       fprintf(stderr, "Usage: [-v] zfs_ids_to_path <pool> <objset id> "
            "<object id>\n");
        exit(err);
 }
@@ -43,18 +43,30 @@ usage(int err)
 int
 main(int argc, char **argv)
 {
-       if (argc != 4) {
+       boolean_t verbose = B_FALSE;
+       char c;
+       while ((c = getopt(argc, argv, "v")) != -1) {
+               switch (c) {
+               case 'v':
+                       verbose = B_TRUE;
+                       break;
+               }
+       }
+       argc -= optind;
+       argv += optind;
+
+       if (argc != 3) {
                (void) fprintf(stderr, "Incorrect number of arguments: %d\n",
                    argc);
                usage(1);
        }

        uint64_t objset, object;
-       if (sscanf(argv[2], "%lu", &objset) != 1) {
+       if (sscanf(argv[1], "%llu", (u_longlong_t *)&objset) != 1) {
                (void) fprintf(stderr, "Invalid objset id: %s\n", argv[2]);
                usage(2);
        }
-       if (sscanf(argv[3], "%lu", &object) != 1) {
+       if (sscanf(argv[2], "%llu", (u_longlong_t *)&object) != 1) {
                (void) fprintf(stderr, "Invalid object id: %s\n", argv[3]);
                usage(3);
        }
@@ -62,7 +74,7 @@ main(int argc, char **argv)
                (void) fprintf(stderr, "%s\n", libzfs_error_init(errno));
                return (4);
        }
-       zpool_handle_t *pool = zpool_open(g_zfs, argv[1]);
+       zpool_handle_t *pool = zpool_open(g_zfs, argv[0]);
        if (pool == NULL) {
                fprintf(stderr, "Could not open pool %s\n", argv[1]);
                libzfs_fini(g_zfs);
@@ -70,7 +82,13 @@ main(int argc, char **argv)
        }

        char pathname[PATH_MAX * 2];
-       zpool_obj_to_path(pool, objset, object, pathname, PATH_MAX * 2);
+       if (verbose) {
+               zpool_obj_to_path_ds(pool, objset, object, pathname,
+                   sizeof (pathname));
+       } else {
+               zpool_obj_to_path(pool, objset, object, pathname,
+                   sizeof (pathname));
+       }
        printf("%s\n", pathname);
        zpool_close(pool);
        libzfs_fini(g_zfs);
```
= Extra changes

Had to add `man8/zfs_ids_to_path.8` to the debian package:

```diff
sdimitropoulos@duneboy:~/rep/linda/zfs/debian$ git diff
diff --git a/debian/zfsutils-linux.install b/debian/zfsutils-linux.install
index 100aad0da..d55e58c8e 100644
--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -75,6 +75,7 @@ usr/share/man/man8/zfs-unmount.8
 usr/share/man/man8/zfs-upgrade.8
 usr/share/man/man8/zfs-userspace.8
 usr/share/man/man8/zfs-wait.8
+usr/share/man/man8/zfs_ids_to_path.8
 usr/share/man/man8/zfsconcepts.8
 usr/share/man/man8/zfsprops.8
 usr/share/man/man8/zdb.8
```

= Testing

Compiled and loaded the code to sd-zfs-make.dcenter.
Ran the following automation:
zfs-precommit (pending): http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5236/flowGraphTable/
ab-pre-push (pending): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3499/flowGraphTable/