### PR TITLE
DLPX-70719 [Backport of DLPX-70703 to 6.0.3.0] arc shrinking stalls allocations

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -4149,6 +4149,15 @@ arc_evict_state_impl(multilist_t *ml, int idx, arc_buf_hdr_t *marker,
 
 	multilist_sublist_unlock(mls);
 
+	/*
+	 * If the ARC size is reduced from arc_c_max to arc_c_min (especially
+	 * if the average cached block is small), eviction can be on-CPU for
+	 * many seconds.  To ensure that other threads that may be bound to
+	 * this CPU are able to make progress, make a voluntary preemption
+	 * call here.
+	 */
+	cond_resched();
+
 	return (bytes_evicted);
 }
 
@@ -5372,6 +5381,24 @@ __arc_shrinker_func(struct shrinker *shrink, struct shrink_control *sc)
 	 */
 	if (pages > 0) {
 		arc_reduce_target_size(ptob(sc->nr_to_scan));
+
+		/*
+		 * Repeated calls to the arc shrinker can reduce arc_c
+		 * drastically, potentially all the way to arc_c_min.  While
+		 * arc_c is below arc_size, ZFS can't process read/write
+		 * requests, because arc_get_data_impl() will block.  To
+		 * ensure that arc_c doesn't shrink faster than the adjust
+		 * thread can keep up, we wait for eviction here.
+		 */
+		mutex_enter(&arc_adjust_lock);
+		if (arc_is_overflowing()) {
+			arc_adjust_needed = B_TRUE;
+			zthr_wakeup(arc_adjust_zthr);
+			(void) cv_wait(&arc_adjust_waiters_cv,
+			    &arc_adjust_lock);
+		}
+		mutex_exit(&arc_adjust_lock);
+
 		if (current_is_kswapd())
 			arc_kmem_reap_soon();
 #ifdef HAVE_SPLIT_SHRINKER_CALLBACK


### PR DESCRIPTION

ZFS registers a memory hook (__arc_shrinker_func) which is supposed to allows the arc to shrink when the kernel experiences memory pressure. The logic, however, only adjusts the size of arc_c but does not wait for the eviction to happen. Since this function is called repeatedly, it results in a quick drop of the arc_c value all the way down to arc_c_min and since it doesn't wait for the actual eviction of the data from the arc it creates a situation where arc_size > arc_c. This condition causes all new allocations to stall in arc_get_data_impl:
```
     /*
      * If arc_size is currently overflowing, and has grown past our
      * upper limit, we must be adding data faster than the evict
      * thread can evict. Thus, to ensure we don't compound the
      * problem by adding more data and forcing arc_size to grow even
      * further past it's target size, we halt and wait for the
      * eviction thread to catch up.
      *
      * It's also possible that the reclaim thread is unable to evict
      * enough buffers to get arc_size below the overflow limit (e.g.
      * due to buffers being un-evictable, or hash lock collisions).
      * In this case, we want to proceed regardless if we're
      * overflowing; thus we don't use a while loop here.
      */
     if (arc_is_overflowing()) {
         mutex_enter(&arc_adjust_lock);
 
         /*
          * Now that we've acquired the lock, we may no longer be
          * over the overflow limit, lets check.
          *
          * We're ignoring the case of spurious wake ups. If that
          * were to happen, it'd let this thread consume an ARC
          * buffer before it should have (i.e. before we're under
          * the overflow limit and were signalled by the reclaim
          * thread). As long as that is a rare occurrence, it
          * shouldn't cause any harm.
          */
         if (arc_is_overflowing()) {
             arc_adjust_needed = B_TRUE;
             zthr_wakeup(arc_adjust_zthr);
             (void) cv_wait(&arc_adjust_waiters_cv,
                 &arc_adjust_lock);
         }
         mutex_exit(&arc_adjust_lock);
     }
```
This leads to multiple second stalls for random I/Os. The following commit inadvertently changed the memory callback from doing synchronous arc eviction to an async nature:
```
commit 3ec34e55271d433e3c2dbb861a886361e006ca0a
Author: Brad Lewis <brad.lewis@delphix.com>
Date:   Wed Mar 15 16:41:52 2017 -0700
CommitDate: Wed Dec 26 13:22:28 2018 -0800

    OpenZFS 9284 - arc_reclaim_thread has 2 jobs
```
In order to prevent the I/O stalls, we need to wait for the eviction to complete before returning from the shrinker code.

```
		 * Repeated calls to the arc shrinker can reduce arc_c
		 * drastically, potentially all the way to arc_c_min.  While
		 * arc_c is below arc_size, ZFS can't process read/write
		 * requests, because arc_get_data_impl() will block.  To
		 * ensure that arc_c doesn't shrink faster than the adjust
		 * thread can keep up, we wait for eviction here.
```


Additionally, this extreme shrinking can cause the arc_adjust_zthr to be on CPU for many seconds, which can starve out the bio threads which are bound to each CPU.  So the arc_adjust_zthr should periodically do a voluntary preemption.

```
	 * If the ARC size is reduced from arc_c_max to arc_c_min (especially
	 * if the average cached block is small), eviction can be on-CPU for
	 * many seconds.  To ensure that other threads that may be bound to
	 * this CPU are able to make progress, make a voluntary preemption
	 * call here.
```


