### PR TITLE
Fix warning in libshare/nfs.c

### DIFF
--- a/lib/libshare/nfs.c
+++ b/lib/libshare/nfs.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <libgen.h>
 #include <libzfs.h>
+#include <libzfs_impl.h>
 #include <libshare.h>
 #include "libshare_impl.h"
 #include "nfs.h"


### PR DESCRIPTION
`git zfs-make` (without `-P`) fails with the following warning:

```
make[3]: Entering directory '/export/home/delphix/zfs/lib/libshare'
  CC       nfs.lo
nfs.c:239:1: error: no previous prototype for ‘nfs_exports_lock’ [-Werror=missing-prototypes]
 nfs_exports_lock(void)
 ^~~~~~~~~~~~~~~~
nfs.c:293:1: error: no previous prototype for ‘nfs_exports_unlock’ [-Werror=missing-prototypes]
 nfs_exports_unlock(void)
 ^~~~~~~~~~~~~~~~~~
Makefile:698: recipe for target 'nfs.lo' failed
```

It appears to have been introduced by ae7b167a98b482605 (Enable
-Wmissing-prototypes/-Wstrict-prototypes).  However, it doesn't cause a
failure in the automated builds, so this commit was auto-merged
successfully.  Presumably they work because they are nondebug and
therefore don't do this check.

