### PR TITLE
6.0.3.0: arcstat: add 'avail', fix 'free'

### DIFF
--- a/cmd/arcstat/arcstat
+++ b/cmd/arcstat/arcstat
@@ -96,6 +96,7 @@ cols = {
     "grow":       [4, 1000, "ARC Grow disabled"],
     "need":       [4, 1024, "ARC Reclaim need"],
     "free":       [4, 1024, "ARC Free memory"],
+    "avail":      [4, 1024, "ARC available memory"],
 }
 
 v = {}
@@ -197,7 +198,7 @@ def prettynum(sz, scale, num=0):
     elif 0 < num < 1:
         num = 0
 
-    while num > scale and index < 5:
+    while abs(num) > scale and index < 5:
         save = num
         num = num / scale
         index += 1
@@ -205,7 +206,7 @@ def prettynum(sz, scale, num=0):
     if index == 0:
         return "%*d" % (sz, num)
 
-    if (save / scale) < 10:
+    if abs(save / scale) < 10:
         return "%*.1f%s" % (sz - 1, num, suffix[index])
     else:
         return "%*d%s" % (sz - 1, num, suffix[index])
@@ -429,7 +430,8 @@ def calculate():
 
     v["grow"] = 0 if cur["arc_no_grow"] else 1
     v["need"] = cur["arc_need_free"]
-    v["free"] = cur["arc_sys_free"]
+    v["free"] = cur["memory_free_bytes"]
+    v["avail"] = cur["memory_available_bytes"]
 
 
 def main():


### PR DESCRIPTION
Same diff as https://github.com/openzfs/zfs/pull/10494, except that the manpage doesn't exist on 5.3.

We'd like to get this in for enhanced observability.  There's basically zero risk, since this is only used by stats gathering / support bundles.