### PR TITLE
Increase default arc_c_min to accomodate dbuf cache

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7855,8 +7855,14 @@ arc_init(void)
 	arc_need_free = 0;
 #endif
 
-	/* Set min cache to 1/32 of all memory, or 32MB, whichever is more */
-	arc_c_min = MAX(allmem / 32, 2ULL << SPA_MAXBLOCKSHIFT);
+	/*
+	 * Set min cache to 1/8 of all memory, or 32MB, whichever is more.
+	 * Note that this needs to be large enough to contain the entire dbuf
+	 * cache, plus the ARC's copy of this data.  By default the dbuf
+	 * cache is 3/64ths of memory (see dbuf_cache_shift), so this should
+	 * be at least 6/64ths of memory.
+	 */
+	arc_c_min = MAX(allmem / 8, 2ULL << SPA_MAXBLOCKSHIFT);
 	/* set max to 1/2 of all memory */
 	arc_c_max = MAX(allmem / 2, arc_c_min);
 


### PR DESCRIPTION
The arc target size `arc_c` needs to be at least large enough to contain
the entire dbuf cache, plus the ARC's copy of this data.  Otherwise we
could be in a situation where `arc_is_overflowing()` is `TRUE` for a
long time, because the ARC can not evict data to get down to the target
size, because the data is pinned by the dbuf cache.  This can cause ZFS
operations to pause while `arc_get_data_impl()` waits for the ARC to no
longer be "overflowing".

The dbuf cache is 3/64ths of memory (see `dbuf_cache_shift` and
`dbuf_metadata_cache_shift`), so the ARC needs to be at least 6/64ths of
memory, to include both the dbuf cache and the additional copy in the
ARC.

This commit changes the minimum arc size `arc_c_min` to be 1/8th of all
memory.

upstream PR: https://github.com/openzfs/zfs/pull/10562