### PR TITLE
Fixes for zfs wait backport

### DIFF
--- a/module/zfs/dsl_dir.c
+++ b/module/zfs/dsl_dir.c
@@ -2317,8 +2317,8 @@ dsl_dir_activity_in_progress(dsl_dir_t *dd, dsl_dataset_t *ds,
 		}
 
 		uint64_t readonly = B_FALSE;
-		error = zfs_get_temporary_prop(ds, ZFS_PROP_READONLY, &readonly,
-		    NULL);
+		error = dsl_prop_get_int_ds(ds,
+		    zfs_prop_to_name(ZFS_PROP_READONLY), &readonly);
 
 		if (error != 0)
 			break;

--- a/tests/runfiles/linux.run
+++ b/tests/runfiles/linux.run
@@ -295,6 +295,10 @@ tests = ['zfs_upgrade_001_pos', 'zfs_upgrade_002_pos', 'zfs_upgrade_003_pos',
     'zfs_upgrade_007_neg']
 tags = ['functional', 'cli_root', 'zfs_upgrade']
 
+[tests/functional/cli_root/zfs_wait]
+tests = ['zfs_wait_deleteq']
+tags = ['functional', 'cli_root', 'zfs_wait']
+
 [tests/functional/cli_root/zpool]
 tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 tags = ['functional', 'cli_root', 'zpool']


### PR DESCRIPTION

### Motivation and Context
The original push contained a call to zfs_get_temporary_prop(), which
doesn't exist in 6.0/stage. Also, the new tests were not running
because they weren't added to the runfile.

### Description
Introduce a fix for the lack of zfs_get_temporary_prop (provided by
Paul) and add the tests to the runfile

### How Has This Been Tested?
http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5383/

The failures in ZTS are all known and unrelated to this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [x] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
