### PR TITLE
arc_shrinker_scan should set reclaimed_slab

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -5346,6 +5346,8 @@ arc_shrinker_scan(struct shrinker *shrink, struct shrink_control *sc)
 	 */
 	arc_reduce_target_size(ptob(sc->nr_to_scan));
 	arc_wait_for_eviction(ptob(sc->nr_to_scan));
+	if (current->reclaim_state != NULL)
+		current->reclaim_state->reclaimed_slab += sc->nr_to_scan;
 
 	/*
 	 * We are experiencing memory pressure which the arc_evict_zthr was


### PR DESCRIPTION
Setting reclaimed_slab from the shrinker callback lets the kernel's
shrinker code know that we are making progress (it increments 
`struct scan_control:nr_reclaimed`).  This should cause the shrinker code to
keep calling this callback if it needs to free more.  Although the ARC
shrinker callback tries to keep enough free memory that subsequent calls
won't be needed, it doesn't know about higher-order pages (i.e. runs of
physically-contiguous pages).

For example, `should_continue_reclaim()` will return `false` if there
was no progress (`nr_reclaimed==0`).  This will cause `shrink_node()` to
return after one iteration, which may be insufficient to find high-order
pages.

