### PR TITLE
Fix merge conflict

### DIFF
--- a/etc/systemd/system/zfs-import-cache.service.in
+++ b/etc/systemd/system/zfs-import-cache.service.in
@@ -10,11 +10,11 @@ After=multipathd.target
 After=systemd-remount-fs.service
 Before=zfs-import.target
 ConditionPathExists=@sysconfdir@/zfs/zpool.cache
+ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zpool import -c @sysconfdir@/zfs/zpool.cache -aN
 
 [Install]

--- a/etc/systemd/system/zfs-import-scan.service.in
+++ b/etc/systemd/system/zfs-import-scan.service.in
@@ -9,11 +9,11 @@ After=cryptsetup.target
 After=multipathd.target
 Before=zfs-import.target
 ConditionPathExists=!@sysconfdir@/zfs/zpool.cache
+ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zpool import -aN -o cachefile=none
 
 [Install]

--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@ -5,11 +5,11 @@ DefaultDependencies=no
 After=systemd-udev-settle.service
 After=zfs-import.target
 After=systemd-remount-fs.service
+ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/usr/bin/grep -q "^zfs " /proc/modules
 ExecStart=@sbindir@/zfs mount -a
 
 [Install]


### PR DESCRIPTION
Merge conflict was caused by a new line that was added in zfs-mount.service.in, right after 2 lines that we deleted.

```
diff --cc etc/systemd/system/zfs-mount.service.in
index cdbcc2a8c,480f39a49..04a06fd8e
--- a/etc/systemd/system/zfs-mount.service.in
+++ b/etc/systemd/system/zfs-mount.service.in
@@@ -5,6 -5,9 +5,7 @@@ DefaultDependencies=n
  After=systemd-udev-settle.service
  After=zfs-import.target
  After=systemd-remount-fs.service
 -Before=local-fs.target
 -Before=systemd-random-seed.service
+ ConditionPathIsDirectory=/sys/module/zfs

  [Service]
  Type=oneshot
```

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3824/