### PR TITLE
 Try using BLKPG for resizing a device (WIP)

### DIFF
--- a/module/os/linux/zfs/vdev_disk.c
+++ b/module/os/linux/zfs/vdev_disk.c
@@ -34,9 +34,9 @@
 #include <sys/abd.h>
 #include <sys/fs/zfs.h>
 #include <sys/zio.h>
+#include <linux/blkpg.h>
 #include <linux/msdos_fs.h>
 #include <linux/vfs_compat.h>
-
 /*
  * Unique identifier for the exclusive vdev holder.
  */
@@ -195,6 +195,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 			blkdev_put(bdev, mode | FMODE_EXCL);
 		}
 
+#ifndef BLKPG_RESIZE_PARTITION
 		if (reread_part) {
 			bdev = blkdev_get_by_path(disk_name, mode | FMODE_EXCL,
 			    zfs_vdev_holder);
@@ -207,6 +208,7 @@ vdev_disk_open(vdev_t *v, uint64_t *psize, uint64_t *max_psize,
 				}
 			}
 		}
+#endif
 	} else {
 		vd = kmem_zalloc(sizeof (vdev_disk_t), KM_SLEEP);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to the issues seen in https://jira.delphix.com/browse/DLPX-70675 (race between device links between destroyed and reopened as part of expanding a vdev), we're interested in finding a way to resize a device's partition using a different ioctl (BLKPG) that doesn't require the device link to be removed. This based on way the partprobe utility resizes partitions. 
### Description
<!--- Describe your changes in detail -->

1. Get the partition location and size information for that data and reserved partitions 
2. Delete the old reserved partition (with `BLKPG_DEL_PARTITION`)
3. Resize the data partition (with `BLKPG_RESIZE_PARTITION`)
4. Add the reserved partition back at it's new offset (with `BLKPG_DEL_PARTITION`)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
Manually tested expanding devices:
```
delphix@sh-6050-expand:~$ lsblk
sdd      8:48   0   12G  0 disk 
├─sdd1   8:49   0   10G  0 part 
└─sdd9   8:57   0    8M  0 part 

delphix@sh-6050-expand:~$ zpool list -v
scsi-36000c29a67489473e20effc8ebfec559  9.50G  16.9M  9.48G        -        2G     0%  0.17%      -  ONLINE  

delphix@sh-6050-expand:~$ sudo zpool online -e domain0 scsi-36000c29a67489473e20effc8ebfec559

delphix@sh-6050-expand:~$ lsblk
sdd      8:48   0   12G  0 disk 
├─sdd1   8:49   0   12G  0 part 
└─sdd9   8:57   0    8M  0 part 

delphix@sh-6050-expand:~$ zpool list -v
scsi-36000c29a67489473e20effc8ebfec559  11.5G  17.5M  11.5G        -         -     0%  0.14%      -  ONLINE  
```
Used `strace` to observe the invocation of the new ioctls:
```
[pid 10977] ioctl(6, BLKPG, {op=BLKPG_DEL_PARTITION, flags=0, datalen=152, data={start=0, length=0, pno=9, devname="", volname=""}}) = 0
[pid 10977] ioctl(6, BLKPG, {op=BLKPG_RESIZE_PARTITION, flags=0, datalen=152, data={start=1048576, length=12874416128, pno=1, devname="/dev/disk/by-id/scsi-36000c29a67489473e20effc8ebfec559-part1", volname=""}}) = 0
[pid 10977] ioctl(6, BLKPG, {op=BLKPG_ADD_PARTITION, flags=0, datalen=152, data={start=12875464704, length=8388608, pno=9, devname="/dev/disk/by-id/scsi-36000c29a67489473e20effc8ebfec559-part1", volname=""}}) = 0
```

Used `udevadm monitor` to confirm that the neither the top level device link or the link to the data partition are ever deleted:
```
KERNEL[802.445605] change   /devices/pci0000:00/0000:00:10.0/host2/target2:0:1/2:0:1:0/block/sdb (block)
KERNEL[802.445899] change   /devices/pci0000:00/0000:00:10.0/host2/target2:0:1/2:0:1:0/block/sdb/sdb1 (block)
KERNEL[802.445926] change   /devices/pci0000:00/0000:00:10.0/host2/target2:0:1/2:0:1:0/block/sdb/sdb9 (block)
KERNEL[802.468172] remove   /devices/pci0000:00/0000:00:10.0/host2/target2:0:1/2:0:1:0/block/sdb/sdb9 (block)
KERNEL[802.468730] add      /devices/pci0000:00/0000:00:10.0/host2/target2:0:1/2:0:1:0/block/sdb/sdb9 (block)
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
