### PR TITLE
Forward-port arc_lowmem_init/arc_sys_free changes from 6.0/stage

### DIFF
--- a/module/os/linux/zfs/arc_os.c
+++ b/module/os/linux/zfs/arc_os.c
@@ -307,46 +307,21 @@ arc_lowmem_init(void)
 	 * arc_wait_for_eviction() will wait until at least the
 	 * high_wmark_pages() are free (see arc_evict_state_impl()).
 	 *
-	 * Note: Even when the system is very low on memory, the kernel's
-	 * shrinker code may only ask for one "batch" of pages (512KB) to be
-	 * evicted.  If concurrent allocations consume these pages, there may
-	 * still be insufficient free pages, and the OOM killer takes action.
-	 *
-	 * By setting arc_sys_free large enough, and having
-	 * arc_wait_for_eviction() wait until there is at least arc_sys_free/2
-	 * free memory, it is much less likely that concurrent allocations can
-	 * consume all the memory that was evicted before checking for
-	 * OOM.
-	 *
 	 * It's hard to iterate the zones from a linux kernel module, which
 	 * makes it difficult to determine the watermark dynamically. Instead
-	 * we compute the maximum high watermark for this system, based
-	 * on the amount of memory, assuming default parameters on Linux kernel
-	 * 5.3.
+	 * we consider the maximum high watermark for any system, assuming
+	 * default parameters on Linux kernel 5.3.  The maximum low watermark
+	 * is 64MB, the max high watermark is 64MB + 0.2% of RAM, and the
+	 * maximum boost is 150% of the high watermark.  So the maximum
+	 * boosted high watermark is 160MB + 0.5% of RAM.
+	 *
+	 * The default arc_sys_free is 512MB + 1/32nd (3%) of RAM, which is
+	 * more than double the highest high_wmark (160MB + 0.5% of RAM).
+	 * Note that the extra 512MB is only strictly necessary on systems
+	 * with less than 16GB of RAM, but we always add it as an extra
+	 * cushion.
 	 */
-
-	/*
-	 * Base wmark_low is 4 * the square root of Kbytes of RAM.
-	 */
-	long wmark = 4 * int_sqrt(allmem/1024) * 1024;
-
-	/*
-	 * Clamp to between 128K and 64MB.
-	 */
-	wmark = MAX(wmark, 128 * 1024);
-	wmark = MIN(wmark, 64 * 1024 * 1024);
-
-	/*
-	 * watermark_boost can increase the wmark by up to 150%.
-	 */
-	wmark += wmark * 150 / 100;
-
-	/*
-	 * arc_sys_free needs to be more than 2x the watermark, because
-	 * arc_wait_for_eviction() waits for half of arc_sys_free.  Bump this up
-	 * to 3x to ensure we're above it.
-	 */
-	arc_sys_free = wmark * 3 + allmem / 32;
+	arc_sys_free = 512 * 1024 * 1024 + allmem / 32;
 }
 
 void


### PR DESCRIPTION
Relevant commit:
67efdea ARC waiters must wait for sufficient free memory

Testing:
- Compiles
- zfs-precommit: http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5435/
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3899/
