### PR TITLE
DLPX-71413 [Backport of DLPX-71306 to 6.0.4.0] 'zfs share -a' retains…

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6547,8 +6547,11 @@ share_mount_one(zfs_handle_t *zhp, int op, int flags, char *protocol,
 		 */
 		if (op == OP_MOUNT)
 			return (0);
-		if (op == OP_SHARE && !zfs_is_mounted(zhp, NULL))
+		if (op == OP_SHARE && !zfs_is_mounted(zhp, NULL)) {
+			/* also purge it from existing exports */
+			zfs_unshareall_bypath(zhp, mountpoint);
 			return (0);
+		}
 	}
 
 	/*


### PR DESCRIPTION
… unmounted dataset that had 'canmount=noauto'

### Motivation and Context
This is a follow on to PR-204 where `zfs share -a`  allows the sharing of `canmount=noauto` datasets if they are mounted.
However, when a dataset with `canmount=noauto` is not mounted, the command should also purge any existing entries from the exports file.  Otherwise, after a reboot, the nfs server attempts to export the underlying mountpath.  This can lead to a hard hang for existing client mounts.

### Description
Instead of just skipping the adding of an export if not mounted and `canmount=noauto`, have it also remove an existing export of the dataset so that, after a reboot, we don't export an unmounted dataset.  The same fix is in an upstream openzfs PR.

### How Has This Been Tested?
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3908/

also tested with a black box run `blackbox.oracle_provision_positive.test_enable_vdb_with_performance_mode_after_restart` against an appliance image that had the fix:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/53644/consoleFull

also manually tested, as follows:
```
$ sudo zfs create -o sharenfs=rw tank/export
$ sudo grep export /etc/exports.d/zfs.exports
/tank/export *(sec=sys,rw,no_subtree_check,mountpoint)
$ sudo cp /etc/exports.d/zfs.exports /etc/exports.d/zfs.exports.bk

$ sudo zfs set canmount=noauto tank/export
$ sudo zfs umount tank/export
$ sudo cp /etc/exports.d/zfs.exports.bk /etc/exports.d/zfs.exports
$ sudo grep export /etc/exports.d/zfs.exports
/tank/export *(sec=sys,rw,no_subtree_check,mountpoint)

$ sudo zfs share -a
$ sudo grep export /etc/exports.d/zfs.exports
$
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)