### PR TITLE
Fix checkstyle bashisms

### DIFF
--- a/debian/tree/zfsutils-linux/usr/share/initramfs-tools/hooks/zdev
+++ b/debian/tree/zfsutils-linux/usr/share/initramfs-tools/hooks/zdev
@@ -54,13 +54,13 @@ do
 	copy_exec "$ii"
 done
 
-if [ -f '/etc/default/zfs' -a -r '/etc/default/zfs' ]
+if [ -f '/etc/default/zfs' ] && [ -r '/etc/default/zfs' ]
 then
 	mkdir -p "$DESTDIR/etc/default"
 	cp -a '/etc/default/zfs' "$DESTDIR/etc/default/"
 fi
 
-if [ -d '/etc/zfs' -a -r '/etc/zfs' ]
+if [ -d '/etc/zfs' ] && [ -r '/etc/zfs' ]
 then
 	mkdir -p "$DESTDIR/etc"
 	cp -a '/etc/zfs' "$DESTDIR/etc/"


### PR DESCRIPTION
[This upstream merge PR](https://github.com/delphix/zfs/pull/213) has checkstyle failures that were unrelated to the changes in the commit: 
```
possible bashism in ./debian/tree/zfsutils-linux/usr/share/initramfs-tools/hooks/zdev line 57 (test -a/-o):
if [ -f '/etc/default/zfs' -a -r '/etc/default/zfs' ]
possible bashism in ./debian/tree/zfsutils-linux/usr/share/initramfs-tools/hooks/zdev line 63 (test -a/-o):
if [ -d '/etc/zfs' -a -r '/etc/zfs' ]
make: *** [checkbashisms] Error 1
Makefile:1470: recipe for target 'checkbashisms' failed 
```
This PR is to fix those bashisms.   The first version of this PR was garbage.  Thanks Prakash for waking me up.   What is being
complained about is using -a as the logical and.   I believe this can replaced with && if an additional sh square brace("[ ]") command is added.  This test checks for the existance of anyfile using the 2 command if form.   It then also uses the exact conditionals from the if statements that are being changed in debian/tree/zfsutils-linux/usr/share/initramfs-tools/hooks/zdev to look for /etc/default/zfs and /etc/zfs.   Then I modified those string constants slightly to make sure it doesn't always return true and look for  /etc/default/notzfs and /etc/notsfs.

```$ cat file_exists.sh
#!/bin/sh

if [ -f $1 ] &&  [ -r $1 ] 
then
	echo "Found $1"
fi

if [ -f '/etc/default/zfs' ] && [ -r '/etc/default/zfs' ]
then
	echo "Found /etc/default/zfs"
fi

if [ -d '/etc/zfs' ] && [ -r '/etc/zfs' ]
then
	echo "Found /etc/zfs"
fi

if [ -f '/etc/default/notzfs' ] && [ -r '/etc/default/notzfs' ]
then
	echo "Found /etc/default/notzfs"
fi

if [ -d '/etc/notzfs' ] && [ -r '/etc/notzfs' ]
then
	echo "Found /etc/notzfs"
fi 
```
I ran it with an existing file as the argument and a filename for a nonexistent file.
```
blewis@brad-trunk-test:~$ touch /tmp/test_exists
blewis@brad-trunk-test:~$ ./file_exists.sh /tmp/test_exists
Found /tmp/test_exists
Found /etc/default/zfs
Found /etc/zfs
blewis@brad-trunk-test:~$ ./file_exists.sh /tmp/test_notexists
Found /etc/default/zfs
Found /etc/zfs
```

Here are ab-pre-push links:
- this one failed but seemed to by an issue downloading the ubuntu packages
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3957/
- clean run
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3963/