### PR TITLE
DLPX-71837 track which blocks of a file have been accessed

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,10 +1,10 @@
 SUBDIRS  = zfs zpool zdb zhack zinject zstream zstreamdump ztest
-SUBDIRS += fsck_zfs vdev_id raidz_test zfs_ids_to_path
+SUBDIRS += fsck_zfs vdev_id raidz_test zfs_ids_to_path zfs_file
 
 if USING_PYTHON
 SUBDIRS += arcstat arc_summary dbufstat
 endif
 
 if BUILD_LINUX
-SUBDIRS += mount_zfs zed zgenhostid zvol_id zvol_wait zfs_ids_to_path
+SUBDIRS += mount_zfs zed zgenhostid zvol_id zvol_wait
 endif

--- a/cmd/zfs_file/Makefile.am
+++ b/cmd/zfs_file/Makefile.am
@@ -1,0 +1,10 @@
+include $(top_srcdir)/config/Rules.am
+
+sbin_PROGRAMS = zfs_file
+
+zfs_file_SOURCES = \
+	zfs_file.c
+
+zfs_file_LDADD = \
+        $(abs_top_builddir)/lib/libzfs/libzfs.la \
+        $(abs_top_builddir)/lib/libzfs_core/libzfs_core.la

--- a/cmd/zfs_file/zfs_file.c
+++ b/cmd/zfs_file/zfs_file.c
@@ -1,0 +1,105 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2020 by Delphix. All rights reserved.
+ */
+#include <libintl.h>
+#include <unistd.h>
+#include <time.h>
+#include <sys/types.h>
+#include <stdint.h>
+#include <libzfs.h>
+#include <libzutil.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+boolean_t parseable = B_FALSE;
+
+static void
+usage(int err)
+{
+	fprintf(stderr, "Usage: [-p] zfs_file <filename> ...\n");
+	exit(err);
+}
+
+static void
+zfs_do_file(const char *filename)
+{
+	zfs_access_info_t zai;
+	int err = zfs_get_access_info(filename, &zai);
+	if (err != 0) {
+		fprintf(stderr, "zfs_get_access_info failed for '%s': %s\n",
+		    filename, strerror(err));
+		if (err == ENOENT)
+			return;
+		exit(1);
+	}
+	time_t start = zai.zai_start;
+	if (parseable) {
+		printf("%llu %llu %llu %s\n",
+		    (long long)start,
+		    (long long)zai.zai_accessed_bytes,
+		    (long long)zai.zai_total_bytes,
+		    filename);
+	} else {
+		char accessed_buf[32];
+		char total_buf[32];
+		zfs_nicenum(zai.zai_accessed_bytes,
+		    accessed_buf, sizeof (accessed_buf));
+		zfs_nicenum(zai.zai_total_bytes, total_buf, sizeof (total_buf));
+		printf("%sB (out of %sB, %u%%) of file '%s' "
+		    "has been accessed since %s",
+		    accessed_buf,
+		    total_buf,
+		    zai.zai_total_bytes == 0 ? 100 :
+		    (int)(zai.zai_accessed_bytes * 100 /
+		    zai.zai_total_bytes),
+		    filename,
+		    ctime(&start));
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	char c;
+	while ((c = getopt(argc, argv, "p")) != -1) {
+		switch (c) {
+		case 'p':
+			parseable = B_TRUE;
+			break;
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 1) {
+		(void) fprintf(stderr, "Missing filename argument\n");
+		usage(1);
+	}
+
+	for (int i = 0; i < argc; i++) {
+		zfs_do_file(argv[i]);
+	}
+
+	return (0);
+}

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_CONFIG_FILES([
 	cmd/zed/Makefile
 	cmd/zed/zed.d/Makefile
 	cmd/zfs/Makefile
+	cmd/zfs_file/Makefile
 	cmd/zfs_ids_to_path/Makefile
 	cmd/zgenhostid/Makefile
 	cmd/zhack/Makefile

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -24,6 +24,7 @@ sbin/zstreamdump
 sbin/zinject
 sbin/zhack
 sbin/zdb
+sbin/zfs_file
 sbin/zfs_ids_to_path
 sbin/zpool
 sbin/zfs

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -912,6 +912,7 @@ extern int zpool_enable_datasets(zpool_handle_t *, const char *, int);
 extern int zpool_disable_datasets(zpool_handle_t *, boolean_t);
 
 extern int zfs_get_hole_count(const char *, uint64_t *, uint64_t *);
+extern int zfs_get_access_info(const char *, zfs_access_info_t *);
 
 #ifdef __FreeBSD__
 

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -902,6 +902,8 @@ typedef struct dmu_object_info {
 	uint64_t doi_physical_blocks_512;	/* data + metadata, 512b blks */
 	uint64_t doi_max_offset;
 	uint64_t doi_fill_count;		/* number of non-empty blocks */
+	time_t doi_accessed_since;
+	uint64_t doi_accessed_bytes;
 } dmu_object_info_t;
 
 typedef void (*const arc_byteswap_func_t)(void *buf, size_t size);

--- a/include/sys/dnode.h
+++ b/include/sys/dnode.h
@@ -353,6 +353,8 @@ struct dnode {
 	 * db_state = DB_SEARCH (see dbuf_free_range for an example).
 	 */
 	avl_tree_t dn_dbufs;
+	time_t dn_accessed_since;
+	range_tree_t *dn_accessed_blocks;
 
 	/* protected by dn_struct_rwlock */
 	struct dmu_buf_impl *dn_bonus;	/* bonus buffer dbuf */

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -1388,6 +1388,18 @@ typedef enum {
 #define	ZFS_IOC_COUNT_FILLED	_IOR('f', 100, uint64_t)
 
 /*
+ * zpl ioctl to get file access info.  Since zai_start, zai_bytes_accessed of
+ * the file have been accessed, out of zai_bytes_total.  The time and counts
+ * are reset when the file is evicted from the cache.
+ */
+typedef struct zfs_access_info {
+	uint64_t zai_accessed_bytes;
+	uint64_t zai_total_bytes;
+	uint64_t zai_start;
+} zfs_access_info_t;
+#define	ZFS_IOC_ACCESS_INFO	_IOR('f', 101, zfs_access_info_t)
+
+/*
  * Internal SPA load state.  Used by FMA diagnosis engine.
  */
 typedef enum {

--- a/lib/libzfs/libzfs_util.c
+++ b/lib/libzfs/libzfs_util.c
@@ -2150,3 +2150,22 @@ zfs_get_hole_count(const char *path, uint64_t *count, uint64_t *bs)
 	}
 	return (0);
 }
+
+int
+zfs_get_access_info(const char *path, zfs_access_info_t *zai)
+{
+	int fd = open(path, O_RDONLY);
+	if (fd == -1)
+		return (errno);
+
+	if (ioctl(fd, ZFS_IOC_ACCESS_INFO, zai) == -1) {
+		int err = errno;
+		(void) close(fd);
+		return (err);
+	}
+
+	if (close(fd) == -1) {
+		return (errno);
+	}
+	return (0);
+}

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -2946,6 +2946,15 @@ dbuf_create(dnode_t *dn, uint8_t level, uint64_t blkid,
 	}
 	avl_add(&dn->dn_dbufs, db);
 
+	/*
+	 * Note: can't use range_tree_contains(), because that only
+	 * returns TRUE if the entire range is in the tree.
+	 */
+	range_tree_clear(dn->dn_accessed_blocks,
+	    db->db.db_offset, db->db.db_size);
+	range_tree_add(dn->dn_accessed_blocks,
+	    db->db.db_offset, db->db.db_size);
+
 	db->db_state = DB_UNCACHED;
 	DTRACE_SET_STATE(db, "regular buffer created");
 	db->db_caching_status = DB_NO_CACHE;

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -2279,6 +2279,8 @@ __dmu_object_info_from_dnode(dnode_t *dn, dmu_object_info_t *doi)
 	doi->doi_fill_count = 0;
 	for (int i = 0; i < dnp->dn_nblkptr; i++)
 		doi->doi_fill_count += BP_GET_FILL(&dnp->dn_blkptr[i]);
+	doi->doi_accessed_since = dn->dn_accessed_since;
+	doi->doi_accessed_bytes = range_tree_space(dn->dn_accessed_blocks);
 }
 
 /*

--- a/module/zfs/dnode_sync.c
+++ b/module/zfs/dnode_sync.c
@@ -572,6 +572,7 @@ dnode_sync_free(dnode_t *dn, dmu_tx_t *tx)
 
 	dnode_undirty_dbufs(&dn->dn_dirty_records[txgoff]);
 	dnode_evict_dbufs(dn);
+	range_tree_vacate(dn->dn_accessed_blocks, NULL, NULL);
 
 	/*
 	 * XXX - It would be nice to assert this, but we may still


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We would like to determine how much of each VDB is accessed as part of the provisioning process (e.g. log replay), and then ongoing how much is further accessed over its lifetime. This will help us to understand how much of the VDB would need to be transmitted or cached.

### Description
<!--- Describe your changes in detail -->
To accomplish that, we add a range_tree to each dnode, which indicates which bytes of the file have been accessed. We update the range_tree when creating a dbuf for this dnode. Note that this information is lost when a dnode is destroyed (e.g. due to cache eviction), but in our use case that is unlikely to happen since there are few files and they are accessed frequently.

A new program, "zfs_file", is added to retrieve this information. It prints the percentage of the file that's been accessed, not exactly which bytes.

Note, this depends on https://github.com/openzfs/zfs/pull/10915.

Future appstack changes will run this periodically against database files and send that info with the phone home bundle.

We plan to backport this to 6.0.5

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->
manual testing of new program, e.g.: 
```
# find /lib -size +1M | xargs zfs_file
0B (out of 15.6MB, 0%) of file '/lib/libzpool.so.2.0.0' has been accessed since Thu Sep 10 23:08:38 2020
512KB (out of 1.88MB, 26%) of file '/lib/libzfs.so.2.0.0' has been accessed since Thu Sep 10 23:00:32 2020
0B (out of 4.12MB, 0%) of file '/lib/libzfs.a' has been accessed since Thu Sep 10 23:08:38 2020
1.38MB (out of 1.38MB, 100%) of file '/lib/modules/5.4.0-42-generic/modules.alias' has been accessed since Thu Sep 10 23:01:56 2020
1.12MB (out of 5.50MB, 20%) of file '/lib/modules/5.4.0-42-generic/extra/zfs/zfs.ko' has been accessed since Thu Sep 10 23:01:51 2020
0B (out of 3.62MB, 0%) of file '/lib/modules/5.4.0-42-generic/kernel/zfs/zfs.ko' has been accessed since Thu Sep 10 23:08:38 2020
256KB (out of 3.50MB, 7%) of file '/lib/modules/5.4.0-42-generic/kernel/kernel/kheaders.ko' has been accessed since Thu Sep 10 23:01:52 2020
384KB (out of 1.75MB, 21%) of file '/lib/modules/5.4.0-42-generic/kernel/lib/test_bpf.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 1.38MB, 45%) of file '/lib/modules/5.4.0-42-generic/kernel/net/mac80211/mac80211.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 1.12MB, 55%) of file '/lib/modules/5.4.0-42-generic/kernel/net/wireless/cfg80211.ko' has been accessed since Thu Sep 10 23:01:52 2020
768KB (out of 3MB, 25%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/gpu/drm/nouveau/nouveau.ko' has been accessed since Thu Sep 10 23:01:52 2020
768KB (out of 3.12MB, 24%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/gpu/drm/i915/i915.ko' has been accessed since Thu Sep 10 23:01:52 2020
1.25MB (out of 6.62MB, 18%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 2.12MB, 29%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/gpu/drm/radeon/radeon.ko' has been accessed since Thu Sep 10 23:01:52 2020
512KB (out of 1.38MB, 36%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/scsi/lpfc/lpfc.ko' has been accessed since Thu Sep 10 23:01:52 2020
512KB (out of 1.12MB, 44%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/scsi/qla2xxx/qla2xxx.ko' has been accessed since Thu Sep 10 23:01:52 2020
512KB (out of 1.38MB, 36%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko' has been accessed since Thu Sep 10 23:01:52 2020
512KB (out of 1.12MB, 44%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/net/ethernet/mellanox/mlxsw/mlxsw_spectrum.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 1.38MB, 45%) of file '/lib/modules/5.4.0-42-generic/kernel/drivers/infiniband/hw/hfi1/hfi1.ko' has been accessed since Thu Sep 10 23:01:52 2020
768KB (out of 2MB, 37%) of file '/lib/modules/5.4.0-42-generic/kernel/fs/xfs/xfs.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 2MB, 31%) of file '/lib/modules/5.4.0-42-generic/kernel/fs/btrfs/btrfs.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 1.75MB, 35%) of file '/lib/modules/5.4.0-42-generic/kernel/fs/cifs/cifs.ko' has been accessed since Thu Sep 10 23:01:52 2020
640KB (out of 1.62MB, 38%) of file '/lib/modules/5.4.0-42-generic/kernel/fs/ocfs2/ocfs2.ko' has been accessed since Thu Sep 10 23:01:52 2020
1.38MB (out of 1.38MB, 100%) of file '/lib/modules/5.4.0-42-generic/modules.alias.bin' has been accessed since Thu Sep 10 23:01:57 2020
0B (out of 30.5MB, 0%) of file '/lib/libzpool.a' has been accessed since Thu Sep 10 23:08:38 2020
2.12MB (out of 2.12MB, 100%) of file '/lib/systemd/libsystemd-shared-237.so' has been accessed since Thu Sep 10 23:00:31 2020
1.62MB (out of 1.62MB, 100%) of file '/lib/systemd/systemd' has been accessed since Thu Sep 10 23:00:31 2020
1.50MB (out of 1.62MB, 92%) of file '/lib/systemd/systemd-networkd' has been accessed since Thu Sep 10 23:00:35 2020
2.75MB (out of 8.62MB, 31%) of file '/lib/udev/hwdb.bin' has been accessed since Thu Sep 10 23:00:31 2020
0B (out of 2.88MB, 0%) of file '/lib/udev/hwdb.d/20-pci-vendor-model.hwdb' has been accessed since Thu Sep 10 23:08:38 2020
0B (out of 1.62MB, 0%) of file '/lib/udev/hwdb.d/20-OUI.hwdb' has been accessed since Thu Sep 10 23:08:38 2020
0B (out of 1.25MB, 0%) of file '/lib/udev/hwdb.d/20-usb-vendor-model.hwdb' has been accessed since Thu Sep 10 23:08:38 2020
1.88MB (out of 2MB, 93%) of file '/lib/x86_64-linux-gnu/libc-2.27.so' has been accessed since Thu Sep 10 23:00:31 2020
0B (out of 1.25MB, 0%) of file '/lib/x86_64-linux-gnu/libslang.so.2.3.1' has been accessed since Thu Sep 10 23:08:38 2020
1.25MB (out of 1.62MB, 76%) of file '/lib/x86_64-linux-gnu/libm-2.27.so' has been accessed since Thu Sep 10 23:00:31 2020
0B (out of 2.12MB, 0%) of file '/lib/x86_64-linux-gnu/libdns-export.so.1100.1.1' has been accessed since Thu Sep 10 23:08:38 2020
768KB (out of 1.12MB, 66%) of file '/lib/x86_64-linux-gnu/libgcrypt.so.20.2.1' has been accessed since Thu Sep 10 23:00:31 2020
```

http://platform.jenkins.delphix.com/job/devops-gate/job/master/job/zfs-precommit/5483/ (in progress)
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

