### PR TITLE
do not check commit message

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -24,9 +24,9 @@ jobs:
       run: |
         sh ./autogen.sh
         ./configure
-    - name: Checkstyle
+    - name: Codecheck
       run: |
-        make checkstyle
+        make codecheck
     - name: Lint
       run: |
         make lint


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a github action which runs `make checkstyle`, which does
`make codecheck` and `make commitcheck`.  The `commitcheck` part results
in lots of checks that we don't actually want on the Delphix repo.
(e.g. commit line length, signed-off-by).

### Description
<!--- Describe your changes in detail -->
This commit changes the github action to instead run `make codecheck`,
which only checks the style of the code, which we do want to match the
upstream style so that we don't have diffs when upstreaming.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

Applied this change to https://github.com/ahrens/zfs and then opened https://github.com/ahrens/zfs/pull/16.  Test results: https://github.com/ahrens/zfs/pull/16/checks?check_run_id=1162400005
