### PR TITLE
6.0: do not check commit message

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -24,9 +24,9 @@ jobs:
       run: |
         sh ./autogen.sh
         ./configure
-    - name: Checkstyle
+    - name: Codecheck
       run: |
-        make checkstyle
+        make codecheck
     - name: Lint
       run: |
         make lint


### PR DESCRIPTION
clean backport of https://github.com/delphix/zfs/pull/223.

As shown in https://github.com/delphix/zfs/pull/221, PR's against 6.0/stage are not using the workflows in master.