### PR TITLE
DLPX-72754 [Backport of DLPX-72753 to 6.0.6.0] initramfs: zfsunlock hook breaks /usr/bin

### DIFF
--- a/contrib/initramfs/hooks/zfsunlock.in
+++ b/contrib/initramfs/hooks/zfsunlock.in
@@ -15,4 +15,4 @@ esac
 
 . /usr/share/initramfs-tools/hook-functions
 
-copy_exec /usr/share/initramfs-tools/zfsunlock /usr/bin
+copy_exec /usr/share/initramfs-tools/zfsunlock /usr/bin/zfsunlock


### PR DESCRIPTION
Clean cherry-pick of https://github.com/openzfs/zfs/pull/11162

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4301