### PR TITLE
assertion failed: fragmentation <= 100

### DIFF
--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -990,7 +990,20 @@ metaslab_group_initialized(metaslab_group_t *mg)
 uint64_t
 metaslab_group_get_space(metaslab_group_t *mg)
 {
-	return ((1ULL << mg->mg_vd->vdev_ms_shift) * mg->mg_vd->vdev_ms_count);
+	uint64_t space = 0;
+	avl_tree_t *t = &mg->mg_metaslab_tree;
+	mutex_enter(&mg->mg_lock);
+	for (metaslab_t *msp = avl_first(t);
+	    msp != NULL; msp = AVL_NEXT(t, msp)) {
+		/* skip if not a member */
+		if (msp->ms_group != mg)
+			continue;
+
+		space += msp->ms_size;
+	}
+
+	mutex_exit(&mg->mg_lock);
+	return (space);
 }
 
 void

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -990,21 +990,9 @@ metaslab_group_initialized(metaslab_group_t *mg)
 uint64_t
 metaslab_group_get_space(metaslab_group_t *mg)
 {
-	uint64_t space = 0;
-	avl_tree_t *t = &mg->mg_metaslab_tree;
 	mutex_enter(&mg->mg_lock);
-	for (metaslab_t *msp = avl_first(t);
-	    msp != NULL; msp = AVL_NEXT(t, msp)) {
-		/* skip if not a member */
-		if (msp->ms_group != mg)
-			continue;
-
-		space += msp->ms_size;
-	}
-	VERIFY3U(space, ==,
-	    (1ULL << mg->mg_vd->vdev_ms_shift) *
-	    avl_numnodes(&mg->mg_metaslab_tree));
-
+	uint64_t space = (1ULL << mg->mg_vd->vdev_ms_shift) *
+	    avl_numnodes(&mg->mg_metaslab_tree);
 	mutex_exit(&mg->mg_lock);
 	return (space);
 }
@@ -1028,9 +1016,9 @@ metaslab_group_histogram_verify(metaslab_group_t *mg)
 	mutex_enter(&mg->mg_lock);
 	for (metaslab_t *msp = avl_first(t);
 	    msp != NULL; msp = AVL_NEXT(t, msp)) {
-		/* skip if not active or not a member */
 		VERIFY3P(msp->ms_group, ==, mg);
-		if (msp->ms_sm == NULL || msp->ms_group != mg)
+		/* skip if not active */
+		if (msp->ms_sm == NULL)
 			continue;
 
 		for (int i = 0; i < SPACE_MAP_HISTOGRAM_SIZE; i++) {

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -1001,6 +1001,9 @@ metaslab_group_get_space(metaslab_group_t *mg)
 
 		space += msp->ms_size;
 	}
+	VERIFY3U(space, ==,
+	    (1ULL << mg->mg_vd->vdev_ms_shift) *
+	    avl_numnodes(&mg->mg_metaslab_tree));
 
 	mutex_exit(&mg->mg_lock);
 	return (space);
@@ -1026,6 +1029,7 @@ metaslab_group_histogram_verify(metaslab_group_t *mg)
 	for (metaslab_t *msp = avl_first(t);
 	    msp != NULL; msp = AVL_NEXT(t, msp)) {
 		/* skip if not active or not a member */
+		VERIFY3P(msp->ms_group, ==, mg);
 		if (msp->ms_sm == NULL || msp->ms_group != mg)
 			continue;
 


### PR DESCRIPTION
Since we have embedded slog metaslabs, the calculation in
metaslab_group_get_space() is no longer accurate, because it includes
all metaslabs (including the ZIL metaslab), not just the ones in the
requested group (which is of a particular class, e.g. normal, non-log
class).  Since the returned space is larger than expected, when
metaslab_class_fragmentation() divides by the class's space, we may get
a result >100.

testing:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4317/ (in progress)
manual testing with small, extremely-fragmented pool