### PR TITLE
DLPX-73147 panic: refcount!=0 in dsl_bookmark_destroy_sync_impl

### DIFF
--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -384,6 +384,8 @@ typedef struct dmu_buf {
 #define	DMU_POOL_ZPOOL_CHECKPOINT	"com.delphix:zpool_checkpoint"
 #define	DMU_POOL_LOG_SPACEMAP_ZAP	"com.delphix:log_spacemap_zap"
 #define	DMU_POOL_DELETED_CLONES		"com.delphix:deleted_clones"
+#define	DMU_POOL_BOOKMARK_V2_RECALCULATED \
+	"com.delphix:bookmark_v2_recalculated"
 
 /*
  * Allocate an object from this objset.  The range of object numbers

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -8806,30 +8806,51 @@ spa_sync_upgrades(spa_t *spa, dmu_tx_t *tx)
 		 * has those features that is upgraded to a version with
 		 * BOOKMARK_V2 will crash if the number of bookmarks ever goes
 		 * below the amount that existed when the pool was upgraded.
-		 * This code iterates over all the bookmarks in the system and
-		 * increments the V2 feature once for each bookmark that uses
-		 * either BOOKMARK_WRITTEN or REDACTION_BOOKMARKS.  It's not
-		 * just the sum of the two, because some bookmarks will have
-		 * both REDACTION and WRITTEN, and some could have either
-		 * without the other.
 		 *
-		 * This logic will only execute once because, going forwards,
-		 * any time BOOKMARK_WRITTEN or REDACTION_BOOKMARKS is
-		 * incremented, BOOKMARK_V2 will be as well.  As a result, its
-		 * count should never dip back to zero (maaking in inactive
-		 * but enabled) while the other two are active.
+		 * Additionally, the logic for decrementing BOOKMARK_V2 is
+		 * based on the bookmark's ZAP entry size, not the use of the
+		 * redaction or written fields.  In the current code, these
+		 * values are equivalent (the size is > BOOKMARK_PHYS_SIZE_V1
+		 * if and only if the new fields are in use), but in Delphix
+		 * version 5.0.x.x, a larger size was used unconditionally
+		 * (even if the redaction field was not set). Before Delphix
+		 * version 6.0.6.0, this upgrade code did not take into
+		 * account this possibility, resulting in a lower-than
+		 * expected refcount, and subsequent panics when attempting
+		 * to decrement a zero refcount.  Therefore, we need to
+		 * recalculate the refcount even if it was calculated once
+		 * (by the buggy code).
+		 *
+		 * We only need to recalculate the refcount once (with the
+		 * current algorithm), because now any time BOOKMARK_WRITTEN
+		 * or REDACTION_BOOKMARKS is incremented, BOOKMARK_V2 will be
+		 * as well.
+		 *
+		 * Presence of the DMU_POOL_BOOKMARK_V2_RECALCULATED field
+		 * indicates that it has been recalculated with the current
+		 * algorithm, based on the zap entry size.  After
+		 * recalculating the refcount, if the pool is brought back to
+		 * a system with the buggy upgrade code, that code won't be
+		 * invoked because it's predicated on the V2 refcount being
+		 * nonzero (and if it is zero, that's accurate and the old
+		 * code will leave it at zero). Therefore we can use this
+		 * backwards-compatible field rather than a feature flag.
+		 *
+		 * This upgrade code can be removed once we no longer support
+		 * upgrading from releases before Delphix 6.0.6.0.
 		 */
-		boolean_t bv2_en = spa_feature_is_enabled(spa,
+		boolean_t bv2_enabled = spa_feature_is_enabled(spa,
 		    SPA_FEATURE_BOOKMARK_V2);
-		boolean_t bv2_ac = spa_feature_is_active(spa,
-		    SPA_FEATURE_BOOKMARK_V2);
-
-		boolean_t dep_ac = spa_feature_is_active(spa,
-		    SPA_FEATURE_BOOKMARK_WRITTEN) || spa_feature_is_active(spa,
-		    SPA_FEATURE_REDACTION_BOOKMARKS);
-
-		if (bv2_en && !bv2_ac && dep_ac) {
+		boolean_t recalculated = (zap_contains(spa->spa_meta_objset,
+		    DMU_POOL_DIRECTORY_OBJECT,
+		    DMU_POOL_BOOKMARK_V2_RECALCULATED) == 0);
+		if (bv2_enabled && !recalculated) {
 			dsl_pool_sync_bookmark_featureflags(dp, tx);
+			uint64_t one = 1;
+			VERIFY0(zap_add(spa->spa_meta_objset,
+			    DMU_POOL_DIRECTORY_OBJECT,
+			    DMU_POOL_BOOKMARK_V2_RECALCULATED,
+			    sizeof (one), 1, &one, tx));
 		}
 	}
 


### PR DESCRIPTION
see [DLPX-73147](https://jira.delphix.com/browse/DLPX-73147)

I also plan to backport this to 6.0.6.0 and provide as a hotfix on 6.0.4.1 for [ESCL-3277](https://jira.delphix.com/browse/ESCL-3277)

copy-paste from JIRA below:

When migrating from 5.3 to 6.0, the refcount of SPA_FEATURE_BOOKMARK_V2 needs to be adjusted, due to the way we developed our changes years ago without coordinating with ZFS on Linux. This happens by calling sync_bookmark_featureflags_cb() on each dataset when we first import the pool on 6.0+. This function increments the refcount based on whether the bookmark is using new flags that require the V2 feature (HAS_FBN or redaction_obj). However, when the bookmark is deleted, it decrements the refcount based on the size of the ZAP entry (see dsl_bookmark_destroy_sync_impl()). In almost all cases, these are equivalent - the larger ZAP entry size is only used if required due to HAS_FBN or redaction_obj being set, so this difference in logic does not result in any problem.

However, the code in Delphix 5.0.x.x (but not earlier or later releases, i.e. not 4.3.x or 5.1.x) uses a larger ZAP entry even when redaction_obj is not set. Therefore when we counter such a bookmark, the upgrade logic will not increment the refcount, but the deletion logic will decrement the refcount. If the refcount is already zero when we try to decrement it, we'll encounter this VERIFY failure. Note that we may also incorrectly decrement the refcount when it is not zero, leading to the failure at a later time.

The proposed fix is for the upgrade logic to increment the refcount based on the ZAP entry size. This minimizes differences with the upstream code (which doesn't need this upgrade logic at all).

Additionally, to fix any systems that were already upgraded and may have incorrectly calculated the refcount, we will run the new, corrected upgrade logic once when upgrading to the fixed code.

testing notes:
```
bm-5390 HAS_FBN:

zdb -dddd -e -p /net/pharos/export/home/mahrens/vdev bm-5390 |grep "snap = "
                snap = 64
                snap = -8372605183679982075 6 1607370478 0 3 23552 11776 11776 0 0 0


bm-5055 does not have redaction or FBN, but has size > V1:

zdb -dddd -e -p /net/pharos/export/home/mahrens/vdev bm-5055 |grep "snap = "
                snap = 48
                snap = 3768202364483031591 6 1607370595 0


import on master:

from 5390: sets refcount correctly (1), destroys correctly

zpool import -d /net/pharos/export/home/mahrens/vdev bm-5390
zpool set feature@bookmark_v2=enabled bm-5390
zdb -dddd bm-5390 | grep "bookmark_v2"
                com.datto:bookmark_v2 = 1
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 81
zfs destroy bm-5390/test#snap
zdb -dddd bm-5390 | grep "bookmark_v2"
                com.datto:bookmark_v2 = 0
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 81

from 5055: sets refcount incorrectly (0), destroy panics:

zpool import -d /net/pharos/export/home/mahrens/vdev bm-5055
zpool set feature@bookmark_v2=enabled bm-5055
zdb -dddd bm-5055 | grep "bookmark_v2"
                com.datto:bookmark_v2 = 0
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 18
zfs destroy bm-5055/test#snap
        <panic>

import on PR bits:

from 5390: sets refcount correctly (1), destroys correctly

zpool import -d /net/pharos/export/home/mahrens/vdev/to-pr bm-5390
zpool set feature@bookmark_v2=enabled bm-5390
zpool history -i bm-5390 | grep -i v2
        2020-12-07.20:14:01 [txg:26] set feature@bookmark_v2=enabled
        2020-12-07.20:14:01 [txg:26] recalculate SPA_FEATURE_BOOKMARK_V2 refcount old=0 new=1
        2020-12-07.20:14:06 zpool set feature@bookmark_v2=enabled bm-5390
zdb -dddd bm-5390 | grep "bookmark_v2"
                com.delphix:bookmark_v2_recalculated = 1
                com.datto:bookmark_v2 = 1
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 26
zfs destroy bm-5390/test#snap
zdb -dddd bm-5390 | grep "bookmark_v2"
                com.delphix:bookmark_v2_recalculated = 1
                com.datto:bookmark_v2 = 0
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 26

from 5055: sets refcount correctly (1), destroys correctly
zpool import -d /net/pharos/export/home/mahrens/vdev/to-pr bm-5055
zpool set feature@bookmark_v2=enabled bm-5055
zpool history -i bm-5055 | grep -i v2
        2020-12-07.20:17:30 [txg:23] set feature@bookmark_v2=enabled
        2020-12-07.20:17:30 [txg:23] recalculate SPA_FEATURE_BOOKMARK_V2 refcount old=0 new=1
        2020-12-07.20:17:35 zpool set feature@bookmark_v2=enabled bm-5055
zdb -dddd bm-5055 | grep "bookmark_v2"
                com.delphix:bookmark_v2_recalculated = 1
                com.datto:bookmark_v2 = 1
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 23
zfs destroy bm-5055/test#snap
zdb -dddd bm-5055 | grep "bookmark_v2"
                com.delphix:bookmark_v2_recalculated = 1
                com.datto:bookmark_v2 = 0
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 23

5055 -> 5390 -> master -> PR

on 5390:
zpool import -d /net/pharos/export/home/mahrens/vdev/steps bm-5055
zfs bookmark bm-5055/test@snap bm-5055/test#book-5390
zpool set feature@bookmark_written=enabled bm-5055
zfs bookmark bm-5055/test@snap bm-5055/test#book-5390-fbn
zdb -dddd  bm-5055 |grep "snap = "
                snap = 48
                snap = 3768202364483031591 6 1607370595 0
zdb -dddd  bm-5055 |grep "book-5390 = "
                book-5390 = 3768202364483031591 6 1607370595
zdb -dddd  bm-5055 |grep "book-5390-fbn = "
                book-5390-fbn = 3768202364483031591 6 1607370595 0 3 23552 11776 11776 0 0 0

on master:
zpool import -d /net/pharos/export/home/mahrens/vdev/steps bm-5055
zpool set feature@bookmark_v2=enabled bm-5055
zdb -dddd bm-5055 | grep "bookmark_v2"
                com.datto:bookmark_v2 = 1
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 39

on PR:
zpool import -d /net/pharos/export/home/mahrens/vdev/steps bm-5055
zpool history -i bm-5055 | grep -i v2
        2020-12-07.20:33:20 [txg:39] set feature@bookmark_v2=enabled
        2020-12-07.20:33:25 zpool set feature@bookmark_v2=enabled bm-5055
        2020-12-07.20:34:30 [txg:60] recalculate SPA_FEATURE_BOOKMARK_V2 refcount old=1 new=2
zdb -dddd bm-5055 | grep "bookmark_v2"
                com.delphix:bookmark_v2_recalculated = 1
                com.datto:bookmark_v2 = 2
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 39
zfs destroy bm-5055/test#book-5390
zfs destroy bm-5055/test#book-5390-fbn
zfs destroy bm-5055/test#snap
zdb -dddd bm-5055 | grep "bookmark_v2"
                com.delphix:bookmark_v2_recalculated = 1
                com.datto:bookmark_v2 = 0
                com.datto:bookmark_v2 = Support for larger bookmarks
                com.datto:bookmark_v2 = 39
```