### PR TITLE
Merge "Enable ABI checks for the checkstyle workflow"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,7 @@ https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.
 - [ ] Performance enhancement (non-breaking change which improves efficiency)
 - [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
 - [ ] Documentation (a change to man pages or other documentation)
 
 ### Checklist:

--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -18,15 +18,19 @@ jobs:
         sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev python-dev python-setuptools python-cffi python3 python3-dev python3-setuptools python3-cffi
         # packages for tests
         sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
-        sudo apt-get install --yes -qq mandoc cppcheck pax-utils devscripts
+        sudo apt-get install --yes -qq mandoc cppcheck pax-utils devscripts abigail-tools
         sudo -E pip --quiet install flake8
     - name: Prepare
       run: |
         sh ./autogen.sh
         ./configure
+        make -j$(nproc)
     - name: Codecheck
       run: |
         make codecheck
     - name: Lint
       run: |
         make lint
+    - name: CheckABI
+      run: |
+        make checkabi

--- a/tests/runfiles/common.run
+++ b/tests/runfiles/common.run
@@ -402,6 +402,7 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'import_rewind_config_changed',
     'import_rewind_device_replaced']
 tags = ['functional', 'cli_root', 'zpool_import']
+timeout = 1200
 
 [tests/functional/cli_root/zpool_labelclear]
 tests = ['zpool_labelclear_active', 'zpool_labelclear_exported',

--- a/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_concurrent_shares.ksh
@@ -29,7 +29,7 @@
 #
 # DESCRIPTION:
 # Verify that 'zfs set sharenfs=on', 'zfs share', and 'zfs unshare' can
-# run concurrently. The test creates 300 filesystem and 300 threads.
+# run concurrently. The test creates 50 filesystem and 50 threads.
 # Each thread will run through the test strategy in parallel.
 #
 # STRATEGY:
@@ -47,7 +47,7 @@ verify_runnable "global"
 function cleanup
 {
 	wait
-	for fs in $(seq 0 100)
+	for fs in $(seq 0 50)
 	do
 		log_must zfs set sharenfs=off $TESTPOOL/$TESTFS1/$fs
 		log_must zfs set sharenfs=off $TESTPOOL/$TESTFS2/$fs
@@ -79,7 +79,7 @@ function cleanup
 
 function create_filesystems
 {
-	for fs in $(seq 0 100)
+	for fs in $(seq 0 50)
 	do
 		log_must zfs create -p $TESTPOOL/$TESTFS1/$fs
 		log_must zfs create -p $TESTPOOL/$TESTFS2/$fs
@@ -137,7 +137,7 @@ log_onexit cleanup
 create_filesystems
 
 child_pids=()
-for fs in $(seq 0 100)
+for fs in $(seq 0 50)
 do
 	test_share $TESTPOOL/$TESTFS1/$fs &
 	child_pids+=($!)
@@ -158,7 +158,7 @@ log_note "Verify 'zfs share -a' succeeds."
 # Unshare each of the file systems.
 #
 child_pids=()
-for fs in $(seq 0 100)
+for fs in $(seq 0 50)
 do
 	unshare_fs $TESTPOOL/$TESTFS1/$fs &
 	child_pids+=($!)
@@ -181,7 +181,7 @@ log_must zfs share -a
 #
 unset __ZFS_POOL_EXCLUDE
 
-for fs in $(seq 0 100)
+for fs in $(seq 0 50)
 do
 	is_shared $TESTPOOL/$TESTFS1/$fs || \
 	    log_fail "File system $TESTPOOL/$TESTFS1/$fs is not shared"


### PR DESCRIPTION
We made adjacent changes to checkstyle.yaml

```
diff --cc .github/workflows/checkstyle.yaml
index 924fe8c615,1707f5bb21..9db4492cd4
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@@ -24,9 -24,10 +24,10 @@@ jobs
        run: |
          sh ./autogen.sh
          ./configure
+         make -j$(nproc)
 -    - name: Checkstyle
 +    - name: Codecheck
        run: |
 -        make checkstyle
 +        make codecheck
      - name: Lint
        run: |
          make lint
```

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4440/