### PR TITLE
Silence unpackaged_files RPM errors

### DIFF
--- a/rpm/generic/zfs-kmod.spec.in
+++ b/rpm/generic/zfs-kmod.spec.in
@@ -120,6 +120,29 @@ bash %{SOURCE10}  --target %{_target_cpu} %{?repo:--repo %{?repo}} --kmodname %{
     %define debuginfo --disable-debuginfo
 %endif
 
+#
+# = Delphix-Specific Note
+#
+# With the introduction of commit 48edb0029728d72088a1c2c65151fa2390fabf22
+# where we split the debug info as part of `make install`, we started
+# creating these debug files that are not picked up by the process that
+# creates the RPM packages of ZFS. Yet the fact that we don't use them
+# for RPMs is enough for that process to generate errors. With the following
+# `define` statement we silence those errors.
+#
+# This is reasonable for us to do for the following reasons:
+# [1] We don't currently care about RPMs, as our product uses DEBIAN files
+#     and the debug files are picked up by those packages.
+# [2] We won't be getting build failures related to RPMs that are caused
+#     due to this issue in the future anymore, and this is fine because
+#     of [1].
+# [3] This change is not as invasive in the RPM configuration as it would
+#     be to fix it to include those debug files. This is good for avoiding
+#     potential merge conflicts in the future, or at least make them more
+#     straightforward to resolve.
+#
+%define _unpackaged_files_terminate_build 0
+
 # Leverage VPATH from configure to avoid making multiple copies.
 %define _configure ../%{module}-%{version}/configure
 

--- a/rpm/redhat/zfs-kmod.spec.in
+++ b/rpm/redhat/zfs-kmod.spec.in
@@ -61,6 +61,29 @@ fi
 %define debuginfo --disable-debuginfo
 %endif
 
+#
+# = Delphix-Specific Note
+#
+# With the introduction of commit 48edb0029728d72088a1c2c65151fa2390fabf22
+# where we split the debug info as part of `make install`, we started
+# creating these debug files that are not picked up by the process that
+# creates the RPM packages of ZFS. Yet the fact that we don't use them
+# for RPMs is enough for that process to generate errors. With the following
+# `define` statement we silence those errors.
+#
+# This is reasonable for us to do for the following reasons:
+# [1] We don't currently care about RPMs, as our product uses DEBIAN files
+#     and the debug files are picked up by those packages.
+# [2] We won't be getting build failures related to RPMs that are caused
+#     due to this issue in the future anymore, and this is fine because
+#     of [1].
+# [3] This change is not as invasive in the RPM configuration as it would
+#     be to fix it to include those debug files. This is good for avoiding
+#     potential merge conflicts in the future, or at least make them more
+#     straightforward to resolve.
+#
+%define _unpackaged_files_terminate_build 0
+
 %setup -n %{kmod_name}-%{version}
 %build
 %configure \


### PR DESCRIPTION
## Testing

Errors Before this patch:
```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /tmp/zfs-build-runner-uk3xLIor/BUILDROOT/zfs-kmod-2.0.0-rc1.x86_64
4425 error: Installed (but unpackaged) file(s) found:
4426
4427 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/avl/zavl.ko
4428 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/icp/icp.ko
4429 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/lua/zlua.ko
4430 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/nvpair/znvpair.ko
4431 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/spl/spl.ko
4432 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/unicode/zunicode.ko
4433 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/zcommon/zcommon.ko
4434 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/zfs/zfs.ko
4435 /usr/lib/debug/lib/modules/5.4.0-1031-azure/extra/zfs/zstd/zzstd.ko
4436 line 98: Invalid version (double separator '-'): 5.4.0-1031-azure: Provides:         kernel-modules-for-kernel = 5.4.0-1031-azure
4437 line 98: Invalid version (double separator '-'): 5.4.0-1031-azure: Provides:         kmod-zfs-uname-r = 5.4.0-1031-azure
4438 line 98: Invalid version (double separator '-'): 5.4.0-1031-azure: Provides:         kernel-objects-for-kernel = 5.4.0-1031-azure
4439 line 98: Invalid version (double separator '-'): 5.4.0-1031-azure: Provides:         kmod-zfs-devel-uname-r = 5.4.0-1031-azure
```

Used the following to reproduce (copied them from the Github Action):
```
$ sh autogen.sh
$ ./configure --enable-debug --enable-debuginfo
$  make --no-print-directory -s pkg-utils pkg-kmod
```

The errors went away after I applied this patch.