### PR TITLE
embedded slog updates

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -5883,6 +5883,7 @@ zdb_leak_init(spa_t *spa, zdb_cb_t *zcb)
 	 */
 	spa->spa_normal_class->mc_ops = &zdb_metaslab_ops;
 	spa->spa_log_class->mc_ops = &zdb_metaslab_ops;
+	spa->spa_embedded_log_class->mc_ops = &zdb_metaslab_ops;
 
 	zcb->zcb_vd_obsolete_counts =
 	    umem_zalloc(rvd->vdev_children * sizeof (uint32_t *),
@@ -6023,12 +6024,9 @@ zdb_leak_fini(spa_t *spa, zdb_cb_t *zcb)
 
 		for (uint64_t m = 0; m < vd->vdev_ms_count; m++) {
 			metaslab_t *msp = vd->vdev_ms[m];
-			if (!vd->vdev_islog &&
-			    msp->ms_group->mg_class == spa_log_class(spa)) {
-				ASSERT3P(msp->ms_group, ==, vd->vdev_log_mg);
-			} else {
-				ASSERT3P(msp->ms_group, ==, vd->vdev_mg);
-			}
+			ASSERT3P(msp->ms_group, ==, (msp->ms_group->mg_class ==
+			    spa_embedded_log_class(spa)) ?
+			    vd->vdev_log_mg : vd->vdev_mg);
 
 			/*
 			 * ms_allocatable has been overloaded
@@ -6235,6 +6233,8 @@ dump_block_stats(spa_t *spa)
 	zcb.zcb_totalasize = metaslab_class_get_alloc(spa_normal_class(spa));
 	zcb.zcb_totalasize += metaslab_class_get_alloc(spa_special_class(spa));
 	zcb.zcb_totalasize += metaslab_class_get_alloc(spa_dedup_class(spa));
+	zcb.zcb_totalasize +=
+	    metaslab_class_get_alloc(spa_embedded_log_class(spa));
 	zcb.zcb_start = zcb.zcb_lastprint = gethrtime();
 	err = traverse_pool(spa, 0, flags, zdb_blkptr_cb, &zcb);
 
@@ -6282,6 +6282,7 @@ dump_block_stats(spa_t *spa)
 
 	total_alloc = norm_alloc +
 	    metaslab_class_get_alloc(spa_log_class(spa)) +
+	    metaslab_class_get_alloc(spa_embedded_log_class(spa)) +
 	    metaslab_class_get_alloc(spa_special_class(spa)) +
 	    metaslab_class_get_alloc(spa_dedup_class(spa)) +
 	    get_unflushed_alloc_space(spa);
@@ -6346,6 +6347,17 @@ dump_block_stats(spa_t *spa)
 
 		(void) printf("\t%-16s %14llu     used: %5.2f%%\n",
 		    "Dedup class", (u_longlong_t)alloc,
+		    100.0 * alloc / space);
+	}
+
+	if (spa_embedded_log_class(spa)->mc_allocator[0].mca_rotor != NULL) {
+		uint64_t alloc = metaslab_class_get_alloc(
+		    spa_embedded_log_class(spa));
+		uint64_t space = metaslab_class_get_space(
+		    spa_embedded_log_class(spa));
+
+		(void) printf("\t%-16s %14llu     used: %5.2f%%\n",
+		    "Embedded log class", (u_longlong_t)alloc,
 		    100.0 * alloc / space);
 	}
 

--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2018 by Delphix. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -3093,44 +3093,18 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 	/*
 	 * If we have slogs then remove them 1/4 of the time.
 	 */
-	if (spa_has_log_device(spa) && ztest_random(4) == 0) {
-		metaslab_group_t *rotor, *mg;
-		boolean_t slog_found = B_FALSE;
+	if (spa_has_slogs(spa) && ztest_random(4) == 0) {
+		metaslab_group_t *mg;
 
-		mg = rotor = spa_log_class(spa)->mc_allocator[0].mca_rotor;
-		do {
-			if (mg == NULL) {
-				/*
-				 * When we are in the middle of removing a
-				 * log device, the spa may still "have log
-				 * devices" (i.e. spa_log_devices > 0) but
-				 * have no groups in the log class.  See
-				 * spa_vdev_remove_log().
-				 */
-				break;
-			}
-			/*
-			 * Even though we have log devices, we may find
-			 * normal vdevs in the log class because they have
-			 * embedded slog metaslabs.  This can happen because
-			 * we don't disable embedded slog metaslabs when
-			 * adding a log device (after the pool is opened).
-			 */
-			if (mg->mg_vd->vdev_islog) {
-				slog_found = B_TRUE;
-				break;
-			}
-		} while ((mg = mg->mg_next) != rotor);
-
-		if (!slog_found) {
-			spa_config_exit(spa, SCL_VDEV, FTAG);
-			mutex_exit(&ztest_vdev_lock);
-			return;
-		}
-		ASSERT(mg->mg_vd->vdev_islog);
+		/*
+		 * find the first real slog in log allocation class
+		 */
+		mg =  spa_log_class(spa)->mc_allocator[0].mca_rotor;
+		while (!mg->mg_vd->vdev_islog)
+			mg = mg->mg_next;
 
 		guid = mg->mg_vd->vdev_guid;
-		zfs_dbgmsg("removing (%llu) vd %p", guid, mg->mg_vd);
+
 		spa_config_exit(spa, SCL_VDEV, FTAG);
 
 		/*
@@ -3154,7 +3128,7 @@ ztest_vdev_add_remove(ztest_ds_t *zd, uint64_t id)
 		case ZFS_ERR_DISCARDING_CHECKPOINT:
 			break;
 		default:
-			fatal(0, "spa_vdev_remove(%llu) = %d", guid, error);
+			fatal(0, "spa_vdev_remove() = %d", error);
 		}
 	} else {
 		spa_config_exit(spa, SCL_VDEV, FTAG);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -142,9 +142,6 @@ typedef enum dmu_object_byteswap {
 #define	DMU_OT_IS_DDT(ot) \
 	((ot) == DMU_OT_DDT_ZAP)
 
-#define	DMU_OT_IS_ZIL(ot) \
-	((ot) == DMU_OT_INTENT_LOG)
-
 /* Note: ztest uses DMU_OT_UINT64_OTHER as a proxy for file blocks */
 #define	DMU_OT_IS_FILE(ot) \
 	((ot) == DMU_OT_PLAIN_FILE_CONTENTS || (ot) == DMU_OT_UINT64_OTHER)

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -1010,7 +1010,6 @@ typedef enum spa_log_state {
 	SPA_LOG_GOOD,		/* log(s) are good */
 } spa_log_state_t;
 
-extern boolean_t spa_has_log_device(spa_t *spa);
 extern spa_log_state_t spa_get_log_state(spa_t *spa);
 extern void spa_set_log_state(spa_t *spa, spa_log_state_t state);
 extern int spa_reset_logs(spa_t *spa);
@@ -1048,6 +1047,7 @@ extern uint64_t spa_version(spa_t *spa);
 extern boolean_t spa_deflate(spa_t *spa);
 extern metaslab_class_t *spa_normal_class(spa_t *spa);
 extern metaslab_class_t *spa_log_class(spa_t *spa);
+extern metaslab_class_t *spa_embedded_log_class(spa_t *spa);
 extern metaslab_class_t *spa_special_class(spa_t *spa);
 extern metaslab_class_t *spa_dedup_class(spa_t *spa);
 extern metaslab_class_t *spa_preferred_class(spa_t *spa, uint64_t size,
@@ -1094,6 +1094,7 @@ extern boolean_t spa_has_spare(spa_t *, uint64_t guid);
 extern uint64_t dva_get_dsize_sync(spa_t *spa, const dva_t *dva);
 extern uint64_t bp_get_dsize_sync(spa_t *spa, const blkptr_t *bp);
 extern uint64_t bp_get_dsize(spa_t *spa, const blkptr_t *bp);
+extern boolean_t spa_has_slogs(spa_t *spa);
 extern boolean_t spa_is_root(spa_t *spa);
 extern boolean_t spa_writeable(spa_t *spa);
 extern boolean_t spa_has_pending_synctask(spa_t *spa);

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -226,7 +226,7 @@ struct spa {
 	boolean_t	spa_is_exporting;	/* true while exporting pool */
 	metaslab_class_t *spa_normal_class;	/* normal data class */
 	metaslab_class_t *spa_log_class;	/* intent log data class */
-	int		spa_log_devices;	/* number of log devices */
+	metaslab_class_t *spa_embedded_log_class; /* log on normal vdevs */
 	metaslab_class_t *spa_special_class;	/* special allocation class */
 	metaslab_class_t *spa_dedup_class;	/* dedup allocation class */
 	uint64_t	spa_first_txg;		/* first txg after spa_open() */

--- a/include/sys/vdev.h
+++ b/include/sys/vdev.h
@@ -101,7 +101,6 @@ extern void vdev_rele(vdev_t *);
 extern int vdev_metaslab_init(vdev_t *vd, uint64_t txg);
 extern void vdev_metaslab_fini(vdev_t *vd);
 extern void vdev_metaslab_set_size(vdev_t *);
-extern void vdev_metaslab_group_create(vdev_t *vd);
 extern void vdev_expand(vdev_t *vd, uint64_t txg);
 extern void vdev_split(vdev_t *vd);
 extern void vdev_deadman(vdev_t *vd, char *tag);

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -628,6 +628,7 @@ extern int vdev_obsolete_counts_are_precise(vdev_t *vd, boolean_t *are_precise);
  * Other miscellaneous functions
  */
 int vdev_checkpoint_sm_object(vdev_t *vd, uint64_t *sm_obj);
+void vdev_metaslab_group_create(vdev_t *vd);
 
 /*
  * Vdev ashift optimization tunables

--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -1217,20 +1217,6 @@ Default value: \fB0\fR.
 .sp
 .ne 2
 .na
-\fBzfs_max_embedded_slogs\fR (int)
-.ad
-.RS 12n
-If there are no dedicated log devices (slogs), each vdev will "donate" a
-metaslab to be used by the ZIL.  These are called "embedded slog
-metaslabs".  This parameter limits the number of vdevs that will have
-log metaslabs.  If set to 0, there will be no embedded log metaslabs.
-.sp
-Default value: \fBINT_MAX\fR
-.RE
-
-.sp
-.ne 2
-.na
 \fBzfs_max_missing_tvds\fR (int)
 .ad
 .RS 12n
@@ -3948,6 +3934,22 @@ Any writes above that will be executed with lower (asynchronous) priority
 to limit potential SLOG device abuse by single active ZIL writer.
 .sp
 Default value: \fB786,432\fR.
+.RE
+
+.sp
+.ne 2
+.na
+\fBzfs_embedded_slog_min_ms\fR (int)
+.ad
+.RS 12n
+Usually, one metaslab from each (normal-class) vdev is dedicated for use by
+the ZIL (to log synchronous writes).
+However, if there are fewer than zfs_embedded_slog_min_ms metaslabs in the
+vdev, this functionality is disabled.
+This ensures that we don't set aside an unreasonable amount of space for the
+ZIL.
+.sp
+Default value: \fB64\fR.
 .RE
 
 .sp

--- a/module/zfs/vdev_removal.c
+++ b/module/zfs/vdev_removal.c
@@ -1786,8 +1786,7 @@ spa_vdev_remove_cancel_impl(spa_t *spa)
 		vdev_t *vd = vdev_lookup_top(spa, vdid);
 		metaslab_group_activate(vd->vdev_mg);
 		ASSERT(!vd->vdev_islog);
-		if (vd->vdev_log_mg != NULL)
-			metaslab_group_activate(vd->vdev_log_mg);
+		metaslab_group_activate(vd->vdev_log_mg);
 		spa_config_exit(spa, SCL_ALLOC | SCL_VDEV, FTAG);
 	}
 
@@ -2132,8 +2131,7 @@ spa_vdev_remove_top(vdev_t *vd, uint64_t *txg)
 	metaslab_group_t *mg = vd->vdev_mg;
 	metaslab_group_passivate(mg);
 	ASSERT(!vd->vdev_islog);
-	if (vd->vdev_log_mg != NULL)
-		metaslab_group_passivate(vd->vdev_log_mg);
+	metaslab_group_passivate(vd->vdev_log_mg);
 
 	/*
 	 * Wait for the youngest allocations and frees to sync,
@@ -2171,8 +2169,7 @@ spa_vdev_remove_top(vdev_t *vd, uint64_t *txg)
 	if (error != 0) {
 		metaslab_group_activate(mg);
 		ASSERT(!vd->vdev_islog);
-		if (vd->vdev_log_mg != NULL)
-			metaslab_group_activate(vd->vdev_log_mg);
+		metaslab_group_activate(vd->vdev_log_mg);
 		spa_async_request(spa, SPA_ASYNC_INITIALIZE_RESTART);
 		spa_async_request(spa, SPA_ASYNC_TRIM_RESTART);
 		spa_async_request(spa, SPA_ASYNC_AUTOTRIM_RESTART);

--- a/module/zfs/zfs_log.c
+++ b/module/zfs/zfs_log.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2018 by Delphix. All rights reserved.
  */
 
 
@@ -550,7 +550,7 @@ zfs_log_write(zilog_t *zilog, dmu_tx_t *tx, int txtype,
 
 	if (zilog->zl_logbias == ZFS_LOGBIAS_THROUGHPUT)
 		write_state = WR_INDIRECT;
-	else if (!spa_has_log_device(zilog->zl_spa) &&
+	else if (!spa_has_slogs(zilog->zl_spa) &&
 	    resid >= zfs_immediate_write_sz)
 		write_state = WR_INDIRECT;
 	else if (ioflag & (O_SYNC | O_DSYNC))

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -2800,18 +2800,6 @@ zio_write_gang_block(zio_t *pio, metaslab_class_t *mc)
 	error = metaslab_alloc(spa, mc, SPA_GANGBLOCKSIZE,
 	    bp, gbh_copies, txg, pio == gio ? NULL : gio->io_bp, flags,
 	    &pio->io_alloc_list, pio, pio->io_allocator);
-	if (error == ENOSPC && !spa_has_log_device(spa) &&
-	    mc != spa_log_class(spa)) {
-		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
-			zfs_dbgmsg("%s: gang block metaslab allocation "
-			    "failure, trying log class: zio %px",
-			    spa_name(spa), pio);
-		}
-		error = metaslab_alloc(spa, spa_log_class(spa),
-		    SPA_GANGBLOCKSIZE,
-		    bp, gbh_copies, txg, pio == gio ? NULL : gio->io_bp, flags,
-		    &pio->io_alloc_list, pio, pio->io_allocator);
-	}
 	if (error) {
 		if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 			ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
@@ -3485,11 +3473,10 @@ zio_dva_allocate(zio_t *zio)
 	 * Try allocating the block in the usual metaslab class.
 	 * If that's full, allocate it in the normal class.
 	 * If that's full, allocate as a gang block,
-	 * If that's full, allocate it in embedded slog space,
 	 * and if all are full, the allocation fails (which shouldn't happen).
 	 *
-	 * Note that we try ganging before going to embedded slog (ZIL) space,
-	 * to preserve unfragmented slog space, which is critical for decent
+	 * Note that we do not fall back on embedded slog (ZIL) space, to
+	 * preserve unfragmented slog space, which is critical for decent
 	 * sync write performance.  If a log allocation fails, we will fall
 	 * back to spa_sync() which is abysmal for performance.
 	 */
@@ -3512,14 +3499,12 @@ zio_dva_allocate(zio_t *zio)
 			    zio->io_prop.zp_copies, zio->io_allocator, zio);
 			zio->io_flags &= ~ZIO_FLAG_IO_ALLOCATING;
 
-			mc = spa_normal_class(spa);
-			VERIFY(metaslab_class_throttle_reserve(mc,
+			VERIFY(metaslab_class_throttle_reserve(
+			    spa_normal_class(spa),
 			    zio->io_prop.zp_copies, zio->io_allocator, zio,
 			    flags | METASLAB_MUST_RESERVE));
-		} else {
-			mc = spa_normal_class(spa);
 		}
-		zio->io_metaslab_class = mc;
+		zio->io_metaslab_class = mc = spa_normal_class(spa);
 		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
 			zfs_dbgmsg("%s: metaslab allocation failure, "
 			    "trying normal class: zio %px, size %llu, error %d",
@@ -3531,23 +3516,6 @@ zio_dva_allocate(zio_t *zio)
 		    &zio->io_alloc_list, zio, zio->io_allocator);
 	}
 
-	/*
-	 * If ganging won't help, because this allocation is already as small
-	 * as it can get, then use the embedded ZIL metaslabs.
-	 */
-	if (error == ENOSPC && !spa_has_log_device(spa) &&
-	    mc != spa_log_class(spa) &&
-	    zio->io_size <= 1 << spa->spa_min_ashift) {
-		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
-			zfs_dbgmsg("%s: metaslab allocation failure, "
-			    "trying log class: zio %px, size %llu, error %d",
-			    spa_name(spa), zio, zio->io_size, error);
-		}
-		error = metaslab_alloc(spa, spa_log_class(spa),
-		    zio->io_size, bp, zio->io_prop.zp_copies,
-		    zio->io_txg, NULL, flags,
-		    &zio->io_alloc_list, zio, zio->io_allocator);
-	}
 	if (error == ENOSPC && zio->io_size > SPA_MINBLOCKSIZE) {
 		if (zfs_flags & ZFS_DEBUG_METASLAB_ALLOC) {
 			zfs_dbgmsg("%s: metaslab allocation failure, "
@@ -3642,15 +3610,18 @@ zio_alloc_zil(spa_t *spa, objset_t *os, uint64_t txg, blkptr_t *new_bp,
 	int flags = METASLAB_FASTWRITE | METASLAB_ZIL;
 	int allocator = cityhash4(0, 0, 0, os->os_dsl_dataset->ds_object) %
 	    spa->spa_alloc_count;
-	error = metaslab_alloc(spa, spa_log_class(spa), size, new_bp,
-	    1, txg, NULL, flags, &io_alloc_list, NULL, allocator);
-	if (error == 0) {
-		*slog = spa_has_log_device(spa);
-	} else {
-		error = metaslab_alloc(spa, spa_normal_class(spa), size, new_bp,
-		    1, txg, NULL, flags, &io_alloc_list, NULL, allocator);
-		if (error == 0)
-			*slog = FALSE;
+	error = metaslab_alloc(spa, spa_log_class(spa), size, new_bp, 1,
+	    txg, NULL, flags, &io_alloc_list, NULL, allocator);
+	*slog = (error == 0);
+	if (error != 0) {
+		error = metaslab_alloc(spa, spa_embedded_log_class(spa), size,
+		    new_bp, 1, txg, NULL, flags,
+		    &io_alloc_list, NULL, allocator);
+	}
+	if (error != 0) {
+		error = metaslab_alloc(spa, spa_normal_class(spa), size,
+		    new_bp, 1, txg, NULL, flags,
+		    &io_alloc_list, NULL, allocator);
 	}
 	metaslab_trace_fini(&io_alloc_list);
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -572,7 +572,7 @@ zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
 
 	if (zilog->zl_logbias == ZFS_LOGBIAS_THROUGHPUT)
 		write_state = WR_INDIRECT;
-	else if (!spa_has_log_device(zilog->zl_spa) &&
+	else if (!spa_has_slogs(zilog->zl_spa) &&
 	    size >= blocksize && blocksize > zvol_immediate_write_sz)
 		write_state = WR_INDIRECT;
 	else if (sync)

--- a/tests/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh
+++ b/tests/zfs-tests/tests/functional/alloc_class/alloc_class_013_pos.ksh
@@ -40,7 +40,7 @@ log_must display_status "$TESTPOOL"
 # Generate some dedup data in the dedup class before removal
 #
 
-log_must zfs create -o dedup=on -V 1G $TESTPOOL/$TESTVOL
+log_must zfs create -o dedup=on -V 2G $TESTPOOL/$TESTVOL
 
 log_must eval "new_fs $ZVOL_DEVDIR/$TESTPOOL/$TESTVOL >/dev/null 2>&1"
 

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_014_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_014_neg.ksh
@@ -71,7 +71,7 @@ typeset mntp=/mnt
 typeset TMP_FILE=$mntp/tmpfile.$$
 
 create_pool $TESTPOOL $DISK0
-log_must zfs create -V 75m $vol_name
+log_must zfs create -V 100m $vol_name
 block_device_wait
 log_must eval "new_fs ${ZVOL_DEVDIR}/$vol_name > /dev/null 2>&1"
 log_must mount ${ZVOL_DEVDIR}/$vol_name $mntp

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
@@ -70,7 +70,7 @@ log_onexit cleanup
 # use zfs vol device in swap to create pool which should fail.
 #
 create_pool $TESTPOOL $DISK0
-log_must zfs create -V 75m $vol_name
+log_must zfs create -V 100m $vol_name
 block_device_wait
 swap_setup ${ZVOL_DEVDIR}/$vol_name
 


### PR DESCRIPTION
This PR merges the upstream commit for "Set aside a metaslab for ZIL blocks".  It updates the Delphix embedded slog implementation to match that of the upstream PR: https://github.com/openzfs/zfs/pull/11389.  This resolves the largest code difference that we have against upstream, and the source of several recent merge conflicts.

The change in behavior for the Delphix Engine is minimal: single-sector normal-class allocations (typically gang blocks) can no longer fall back to the embedded ZIL metaslab.  In practice this case would never be hit.

There are several changes in the way that it's been implemented:
1. embedded metaslabs are part of the new spa_embedded_log_class (not spa_log_class)
2. embedded metaslabs exist regardless of presence of a log device (dedicated slog)
3. embedded metaslabs only exist if there are at least 64 metaslabs
4. The embedded metaslab space comes out of the 3.2% slop space (reducing the "effective slop space" to 1.6-2.7%, depending on pool size).

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4663/
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4664/