### PR TITLE
DLPX-74369 add diagnostics to root-cause possible bookmark corruption

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2021 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Nexenta Systems, Inc.
  * Copyright (c) 2017, 2018 Lawrence Livermore National Security, LLC.
@@ -2669,7 +2669,7 @@ dump_bookmark(dsl_pool_t *dp, char *name, boolean_t print_redact,
 
 	redaction_list_t *rl;
 	VERIFY0(dsl_redaction_list_hold_obj(dp,
-	    prop.zbm_redaction_obj, FTAG, &rl));
+	    prop.zbm_redaction_obj, FTAG, NULL, &rl));
 
 	redaction_list_phys_t *rlp = rl->rl_phys;
 	(void) printf("\tRedacted:\n\t\tProgress: ");

--- a/include/sys/dsl_bookmark.h
+++ b/include/sys/dsl_bookmark.h
@@ -13,7 +13,7 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2021 by Delphix. All rights reserved.
  */
 
 #ifndef	_SYS_DSL_BOOKMARK_H
@@ -84,6 +84,7 @@ typedef struct dsl_bookmark_node {
 	kmutex_t dbn_lock; /* protects dirty/phys in block_killed */
 	boolean_t dbn_dirty; /* in currently syncing txg */
 	zfs_bookmark_phys_t dbn_phys;
+	uint64_t dbn_redaction_birth_txg;
 	avl_node_t dbn_node;
 } dsl_bookmark_node_t;
 
@@ -131,7 +132,7 @@ int dsl_bookmark_lookup(struct dsl_pool *, const char *,
     struct dsl_dataset *, zfs_bookmark_phys_t *);
 int dsl_bookmark_lookup_impl(dsl_dataset_t *, const char *,
     zfs_bookmark_phys_t *);
-int dsl_redaction_list_hold_obj(struct dsl_pool *, uint64_t, void *,
+int dsl_redaction_list_hold_obj(struct dsl_pool *, uint64_t, void *, dmu_tx_t *,
     redaction_list_t **);
 void dsl_redaction_list_rele(redaction_list_t *, void *);
 void dsl_redaction_list_long_hold(struct dsl_pool *, redaction_list_t *,

--- a/include/sys/dsl_bookmark.h
+++ b/include/sys/dsl_bookmark.h
@@ -23,6 +23,7 @@
 #include <sys/zfs_refcount.h>
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_pool.h>
+#include <sys/dnode.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -84,7 +85,7 @@ typedef struct dsl_bookmark_node {
 	kmutex_t dbn_lock; /* protects dirty/phys in block_killed */
 	boolean_t dbn_dirty; /* in currently syncing txg */
 	zfs_bookmark_phys_t dbn_phys;
-	uint64_t dbn_redaction_birth_txg;
+	uint64_t dbn_redaction_birth_txg[DN_MAX_NBLKPTR];
 	avl_node_t dbn_node;
 } dsl_bookmark_node_t;
 

--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -1203,25 +1203,27 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 			strncat(buf, buf2, 128);
 		}
 		spa_history_log_internal(spa, "finish redaction", NULL,
-		    "name=%s redact_obj=%llu num_entries=%llu %s", newredactbook,
-		    (longlong_t)new_rl->rl_object,
+		    "name=%s redact_obj=%llu num_entries=%llu %s",
+		    newredactbook, (longlong_t)new_rl->rl_object,
 		    (longlong_t)new_rl->rl_phys->rlp_num_entries, buf);
 		kmem_free(buf, 128 * dn->dn_nblkptr);
 		kmem_free(buf2, 128);
 
 		VERIFY0(dsl_pool_hold(snapname, FTAG, &dp));
-		VERIFY0(dsl_bookmark_lookup(dp, newredactbook, NULL, &bookmark));
+		VERIFY0(dsl_bookmark_lookup(dp, newredactbook, NULL,
+		    &bookmark));
 		dsl_bookmark_node_t search = { 0 };
 		search.dbn_phys = bookmark;
 		search.dbn_name = spa_strdup(redactbook);
 		*strchr(newredactbook, '#') = '\0';
 		dsl_dataset_t *head;
 		VERIFY0(dsl_dataset_hold(dp, newredactbook, FTAG, &head));
-		dsl_bookmark_node_t *dbn = avl_find(&head->ds_bookmarks, &search,
-		    NULL);
+		dsl_bookmark_node_t *dbn = avl_find(&head->ds_bookmarks,
+		    &search, NULL);
 		ASSERT3P(dbn, !=, NULL);
 		for (int i = 0; i < dn->dn_nblkptr; i++) {
-			dbn->dbn_redaction_birth_txg[i] = dn->dn_phys->dn_blkptr[i].blk_birth;
+			dbn->dbn_redaction_birth_txg[i] =
+			    dn->dn_phys->dn_blkptr[i].blk_birth;
 		}
 		dsl_dataset_rele(head, FTAG);
 		dsl_pool_rele(dp, FTAG);

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1079,7 +1079,8 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 				    "orig_root_birth=%llu", name,
 				    (longlong_t)dbn->dbn_phys.zbm_redaction_obj,
 				    (u_longlong_t)birth,
-				    (u_longlong_t)dbn->dbn_redaction_birth_txg[i]);
+				    (u_longlong_t)
+				    dbn->dbn_redaction_birth_txg[i]);
 			}
 		}
 		dnode_rele(dn, FTAG);

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2021 by Delphix. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2019, 2020 by Christian Schwarz. All rights reserved.
  */
@@ -334,6 +334,7 @@ dsl_bookmark_node_alloc(char *shortname)
 	dsl_bookmark_node_t *dbn = kmem_alloc(sizeof (*dbn), KM_SLEEP);
 	dbn->dbn_name = spa_strdup(shortname);
 	dbn->dbn_dirty = B_FALSE;
+	dbn->dbn_redaction_birth_txg = 0;
 	mutex_init(&dbn->dbn_lock, NULL, MUTEX_DEFAULT, NULL);
 	return (dbn);
 }
@@ -475,7 +476,7 @@ dsl_bookmark_create_sync_impl_snap(const char *bookmark, const char *snapshot,
 		    SPA_FEATURE_REDACTION_BOOKMARKS, tx);
 
 		VERIFY0(dsl_redaction_list_hold_obj(dp,
-		    dbn->dbn_phys.zbm_redaction_obj, tag, &local_rl));
+		    dbn->dbn_phys.zbm_redaction_obj, tag, tx, &local_rl));
 		dsl_redaction_list_long_hold(dp, local_rl, tag);
 
 		ASSERT3U((local_rl)->rl_dbuf->db_size, >=,
@@ -745,7 +746,7 @@ dsl_bookmark_fetch_props(dsl_pool_t *dp, zfs_bookmark_phys_t *bmark_phys,
 	    bmark_phys->zbm_redaction_obj != 0) {
 		redaction_list_t *rl;
 		int err = dsl_redaction_list_hold_obj(dp,
-		    bmark_phys->zbm_redaction_obj, FTAG, &rl);
+		    bmark_phys->zbm_redaction_obj, FTAG, NULL, &rl);
 		if (err == 0) {
 			if (nvlist_exists(props, "redact_snaps")) {
 				nvlist_t *nvl;
@@ -1043,6 +1044,34 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 	}
 
 	if (dbn->dbn_phys.zbm_redaction_obj != 0) {
+		redaction_list_t *local_rl;
+		dnode_t *dn;
+		VERIFY0(dsl_redaction_list_hold_obj(ds->ds_dir->dd_pool,
+		    dbn->dbn_phys.zbm_redaction_obj, FTAG, tx, &local_rl));
+		VERIFY0(dnode_hold(ds->ds_dir->dd_pool->dp_meta_objset,
+		    dbn->dbn_phys.zbm_redaction_obj, FTAG, &dn));
+		zio_cksum_t *zc = &dn->dn_phys->dn_blkptr[0].blk_cksum;
+		uint64_t birth = dn->dn_phys->dn_blkptr[0].blk_birth;
+		spa_history_log_internal_ds(ds, "remove redaction list", tx,
+		    "name=%s redact_obj=%llu num_entries=%llu root_birth=%llu "
+		    "root_cksum=%llx/%llx/%llx/%llx", name,
+		    (longlong_t)dbn->dbn_phys.zbm_redaction_obj,
+		    (longlong_t)local_rl->rl_phys->rlp_num_entries,
+		    (u_longlong_t)birth, (u_longlong_t)zc->zc_word[0],
+		    (u_longlong_t)zc->zc_word[1], (u_longlong_t)zc->zc_word[2],
+		    (u_longlong_t)zc->zc_word[3]);
+		if (dbn->dbn_redaction_birth_txg != 0 &&
+		    dbn->dbn_redaction_birth_txg != birth) {
+			spa_history_log_internal_ds(ds,
+			    "redaction birth mismatch", tx,
+			    "name=%s redact_obj=%llu root_birth=%llu "
+			    "orig_root_birth=%llu", name,
+			    (longlong_t)dbn->dbn_phys.zbm_redaction_obj,
+			    (u_longlong_t)birth,
+			    (u_longlong_t)dbn->dbn_redaction_birth_txg);
+		}
+		dnode_rele(dn, FTAG);
+		dsl_redaction_list_rele(local_rl, FTAG);
 		VERIFY0(dmu_object_free(mos,
 		    dbn->dbn_phys.zbm_redaction_obj, tx));
 		spa_feature_decr(dmu_objset_spa(mos),
@@ -1097,7 +1126,7 @@ dsl_bookmark_destroy_check(void *arg, dmu_tx_t *tx)
 			if (error == 0 && bm.zbm_redaction_obj != 0) {
 				redaction_list_t *rl = NULL;
 				error = dsl_redaction_list_hold_obj(tx->tx_pool,
-				    bm.zbm_redaction_obj, FTAG, &rl);
+				    bm.zbm_redaction_obj, FTAG, tx, &rl);
 				if (error == ENOENT) {
 					error = 0;
 				} else if (error == 0 &&
@@ -1221,7 +1250,7 @@ dsl_redaction_list_rele(redaction_list_t *rl, void *tag)
 
 int
 dsl_redaction_list_hold_obj(dsl_pool_t *dp, uint64_t rlobj, void *tag,
-    redaction_list_t **rlp)
+    dmu_tx_t *tx, redaction_list_t **rlp)
 {
 	objset_t *mos = dp->dp_meta_objset;
 	dmu_buf_t *dbuf;
@@ -1250,7 +1279,17 @@ dsl_redaction_list_hold_obj(dsl_pool_t *dp, uint64_t rlobj, void *tag,
 			kmem_free(rl, sizeof (*rl));
 			rl = winner;
 		}
+		if (tx != NULL) {
+			spa_history_log_internal(dp->dp_spa,
+			    "holding new redaction", tx, "redact_obj=%llu",
+			    (u_longlong_t)rlobj);
+		}
+	} else if (tx != NULL) {
+		spa_history_log_internal(dp->dp_spa,
+		    "holding existing redaction", tx, "redact_obj=%llu",
+		    (u_longlong_t)rlobj);
 	}
+	VERIFY3U(rlobj, ==, rl->rl_object);
 	*rlp = rl;
 	return (0);
 }


### PR DESCRIPTION
Signed-off-by: Paul Dagnelie <pcd@delphix.com>

We want to integrate these diagnostics on master as well, in case customers encountering this issue want to upgrade to 6.0 before we can resolve the issue. We don't need to backport this to any releases that we don't want the logic to end up in.  This is a relatively clean cherry-pick of the changes from 5.3.9.0 onto Linux.