### PR TITLE
DLPX-74370 [Backport of DLPX-74369 to 6.0.8.0] add diagnostics to root-cause possible bookmark corruption

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2019 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2021 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Nexenta Systems, Inc.
  * Copyright (c) 2017, 2018 Lawrence Livermore National Security, LLC.
@@ -2666,7 +2666,7 @@ dump_bookmark(dsl_pool_t *dp, char *name, boolean_t print_redact,
 
 	redaction_list_t *rl;
 	VERIFY0(dsl_redaction_list_hold_obj(dp,
-	    prop.zbm_redaction_obj, FTAG, &rl));
+	    prop.zbm_redaction_obj, FTAG, NULL, &rl));
 
 	redaction_list_phys_t *rlp = rl->rl_phys;
 	(void) printf("\tRedacted:\n\t\tProgress: ");

--- a/include/sys/dsl_bookmark.h
+++ b/include/sys/dsl_bookmark.h
@@ -13,7 +13,7 @@
  * CDDL HEADER END
  */
 /*
- * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2021 by Delphix. All rights reserved.
  */
 
 #ifndef	_SYS_DSL_BOOKMARK_H
@@ -23,6 +23,7 @@
 #include <sys/zfs_refcount.h>
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_pool.h>
+#include <sys/dnode.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -84,6 +85,7 @@ typedef struct dsl_bookmark_node {
 	kmutex_t dbn_lock; /* protects dirty/phys in block_killed */
 	boolean_t dbn_dirty; /* in currently syncing txg */
 	zfs_bookmark_phys_t dbn_phys;
+	uint64_t dbn_redaction_birth_txg[DN_MAX_NBLKPTR];
 	avl_node_t dbn_node;
 } dsl_bookmark_node_t;
 
@@ -131,7 +133,7 @@ int dsl_bookmark_lookup(struct dsl_pool *, const char *,
     struct dsl_dataset *, zfs_bookmark_phys_t *);
 int dsl_bookmark_lookup_impl(dsl_dataset_t *, const char *,
     zfs_bookmark_phys_t *);
-int dsl_redaction_list_hold_obj(struct dsl_pool *, uint64_t, void *,
+int dsl_redaction_list_hold_obj(struct dsl_pool *, uint64_t, void *, dmu_tx_t *,
     redaction_list_t **);
 void dsl_redaction_list_rele(redaction_list_t *, void *);
 void dsl_redaction_list_long_hold(struct dsl_pool *, redaction_list_t *,


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/zfs/pull/257 onto 6.0/stage
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5014/ (zloop failure appears unrelated)
