### PR TITLE
DLPX-75382 [Backport of DLPX-75381 to 6.0.8.0] Diagnostics collection related to bookmark corruption contains junk values

### DIFF
--- a/module/zfs/dmu_redact.c
+++ b/module/zfs/dmu_redact.c
@@ -1190,6 +1190,7 @@ dmu_redact_snap(const char *snapname, nvlist_t *redactnvl,
 		VERIFY0(dnode_hold(spa_meta_objset(spa), new_rl->rl_object,
 		    FTAG, &dn));
 		char *buf = kmem_alloc(128 * dn->dn_nblkptr, KM_SLEEP);
+		buf[0] = '\0';
 		char *buf2 = kmem_alloc(128, KM_SLEEP);
 		for (int i = 0; i < dn->dn_nblkptr; i++) {
 			zio_cksum_t *zc = &dn->dn_phys->dn_blkptr[i].blk_cksum;

--- a/module/zfs/dsl_bookmark.c
+++ b/module/zfs/dsl_bookmark.c
@@ -1051,6 +1051,7 @@ dsl_bookmark_destroy_sync_impl(dsl_dataset_t *ds, const char *name,
 		VERIFY0(dnode_hold(ds->ds_dir->dd_pool->dp_meta_objset,
 		    dbn->dbn_phys.zbm_redaction_obj, FTAG, &dn));
 		char *buf = kmem_alloc(128 * dn->dn_nblkptr, KM_SLEEP);
+		buf[0] = '\0';
 		char *buf2 = kmem_alloc(128, KM_SLEEP);
 		for (int i = 0; i < dn->dn_nblkptr; i++) {
 			zio_cksum_t *zc = &dn->dn_phys->dn_blkptr[i].blk_cksum;


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/zfs/pull/262 to 6.0/release for 6.0.8.0