### PR TITLE
Implement creation of objstore pools in userland

### DIFF
--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -264,7 +264,7 @@ make_objstore_vdev(nvlist_t *props, const char *arg)
 {
 	nvlist_t *vdev = fnvlist_alloc();
 	char *endpoint, *creds;
-	fnvlist_add_string(vdev, ZPOOL_CONFIG_OBJSTORE_BUCKET, arg);
+	fnvlist_add_string(vdev, ZPOOL_CONFIG_PATH, arg);
 	fnvlist_add_string(vdev, ZPOOL_CONFIG_TYPE, VDEV_TYPE_OBJSTORE);
 
 	if ((nvlist_lookup_string(props,

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -259,6 +259,37 @@ is_spare(nvlist_t *config, const char *path)
 	return (B_FALSE);
 }
 
+static nvlist_t *
+make_objstore_vdev(nvlist_t *props, const char *arg)
+{
+	nvlist_t *vdev = fnvlist_alloc();
+	char *endpoint, *creds;
+	fnvlist_add_string(vdev, ZPOOL_CONFIG_OBJSTORE_BUCKET, arg);
+	fnvlist_add_string(vdev, ZPOOL_CONFIG_TYPE, VDEV_TYPE_OBJSTORE);
+
+	if ((nvlist_lookup_string(props,
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_ENDPOINT), &endpoint)) != 0) {
+		fprintf(stderr, gettext("No endpoint provided for objstore "
+		    "vdev %s\n"), arg);
+		fnvlist_free(vdev);
+		return (NULL);
+	}
+	fnvlist_add_string(vdev, zpool_prop_to_name(ZPOOL_PROP_OBJ_ENDPOINT),
+	    endpoint);
+
+	if ((nvlist_lookup_string(props,
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS), &creds)) != 0) {
+		fprintf(stderr, gettext("No credentials location provided for "
+		    "objstore vdev %s\n"), arg);
+		fnvlist_free(vdev);
+		return (NULL);
+	}
+	fnvlist_add_string(vdev, zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS),
+	    creds);
+
+	return (vdev);
+}
+
 /*
  * Create a leaf vdev.  Determine if this is a file or a device.  If it's a
  * device, fill in the device id to make a complete nvlist.  Valid forms for a
@@ -1106,6 +1137,10 @@ is_device_in_use(nvlist_t *config, nvlist_t *nv, boolean_t force,
 	if (nvlist_lookup_nvlist_array(nv, ZPOOL_CONFIG_CHILDREN,
 	    &child, &children) != 0) {
 
+		if (strcmp(type, VDEV_TYPE_OBJSTORE) == 0) {
+			return (B_FALSE); /* TODO: FIXME */
+		}
+
 		verify(!nvlist_lookup_string(nv, ZPOOL_CONFIG_PATH, &path));
 		if (strcmp(type, VDEV_TYPE_DISK) == 0)
 			verify(!nvlist_lookup_uint64(nv,
@@ -1449,7 +1484,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	int t, toplevels, mindev, maxdev, nspares, nlogs, nl2cache;
 	const char *type, *fulltype;
 	boolean_t is_log, is_special, is_dedup, is_spare;
-	boolean_t seen_logs;
+	boolean_t seen_logs, seen_obj;
 
 	top = NULL;
 	toplevels = 0;
@@ -1459,7 +1494,7 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 	nlogs = 0;
 	nl2cache = 0;
 	is_log = is_special = is_dedup = is_spare = B_FALSE;
-	seen_logs = B_FALSE;
+	seen_logs = seen_obj = B_FALSE;
 	nvroot = NULL;
 
 	while (argc > 0) {
@@ -1644,6 +1679,19 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 					nvlist_free(child[c]);
 				free(child);
 			}
+		} else if (strcmp(fulltype, "s3") == 0) {
+			if (argc == 1) {
+				(void) fprintf(stderr,
+				    gettext("invalid vdev specification: 's3' "
+				    "requires a parameter\n"));
+				goto spec_out;
+			}
+			seen_obj = B_TRUE;
+			if ((nv = make_objstore_vdev(props, argv[1])) == NULL) {
+				goto spec_out;
+			}
+			argc -= 2;
+			argv += 2;
 		} else {
 			/*
 			 * We have a device.  Pass off to make_leaf_vdev() to
@@ -1687,6 +1735,18 @@ construct_spec(nvlist_t *props, int argc, char **argv)
 		(void) fprintf(stderr, gettext("invalid vdev "
 		    "specification: at least one toplevel vdev must be "
 		    "specified\n"));
+		goto spec_out;
+	}
+
+	if (seen_obj && toplevels - nlogs > 1) {
+		(void) fprintf(stderr, gettext("invalid vdev specification: "
+		    "for object storage pools, no other top-level vdevs "
+		    "are allowed\n"));
+		goto spec_out;
+	} else if (seen_obj && nspares != 0) {
+		(void) fprintf(stderr, gettext("invalid vdev specification: "
+		    "for object storage pools, spare devices are not "
+		    "allowed\n"));
 		goto spec_out;
 	}
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -247,6 +247,8 @@ typedef enum {
 	ZPOOL_PROP_LOAD_GUID,
 	ZPOOL_PROP_AUTOTRIM,
 	ZPOOL_PROP_COMPATIBILITY,
+	ZPOOL_PROP_OBJ_ENDPOINT,
+	ZPOOL_PROP_OBJ_CREDENTIALS,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -615,6 +617,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_GUID		"guid"
 #define	ZPOOL_CONFIG_INDIRECT_OBJECT	"com.delphix:indirect_object"
 #define	ZPOOL_CONFIG_INDIRECT_BIRTHS	"com.delphix:indirect_births"
+#define	ZPOOL_CONFIG_OBJSTORE_BUCKET	"com.delphix:bucket_name"
 #define	ZPOOL_CONFIG_PREV_INDIRECT_VDEV	"com.delphix:prev_indirect_vdev"
 #define	ZPOOL_CONFIG_PATH		"path"
 #define	ZPOOL_CONFIG_DEVID		"devid"
@@ -779,6 +782,7 @@ typedef struct zpool_load_policy {
 #define	VDEV_TYPE_LOG			"log"
 #define	VDEV_TYPE_L2CACHE		"l2cache"
 #define	VDEV_TYPE_INDIRECT		"indirect"
+#define	VDEV_TYPE_OBJSTORE		"object_store"
 
 #define	VDEV_RAIDZ_MAXPARITY		3
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -617,7 +617,6 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_GUID		"guid"
 #define	ZPOOL_CONFIG_INDIRECT_OBJECT	"com.delphix:indirect_object"
 #define	ZPOOL_CONFIG_INDIRECT_BIRTHS	"com.delphix:indirect_births"
-#define	ZPOOL_CONFIG_OBJSTORE_BUCKET	"com.delphix:bucket_name"
 #define	ZPOOL_CONFIG_PREV_INDIRECT_VDEV	"com.delphix:prev_indirect_vdev"
 #define	ZPOOL_CONFIG_PATH		"path"
 #define	ZPOOL_CONFIG_DEVID		"devid"

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -75,6 +75,11 @@ zpool_prop_init(void)
 	zprop_register_string(ZPOOL_PROP_COMPATIBILITY, "compatibility",
 	    "off", PROP_DEFAULT, ZFS_TYPE_POOL,
 	    "<file[,file...]> | off | legacy", "COMPATIBILITY");
+	zprop_register_string(ZPOOL_PROP_OBJ_ENDPOINT, "object-endpoint", NULL,
+	    PROP_DEFAULT, ZFS_TYPE_POOL, "<uri>", "OBJ_ENDPOINT");
+	zprop_register_string(ZPOOL_PROP_OBJ_CREDENTIALS,
+	    "object-credentials-location", NULL, PROP_DEFAULT, ZFS_TYPE_POOL,
+	    "<uri>", "OBJ_CREDENTIALS");
 
 	/* readonly number properties */
 	zprop_register_number(ZPOOL_PROP_SIZE, "size", 0, PROP_READONLY,

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -58,6 +58,8 @@ typeset -a properties=(
     "multihost"
     "autotrim"
     "compatibility"
+    "object-endpoint"
+    "object-credentials-location"
     "feature@async_destroy"
     "feature@empty_bpobj"
     "feature@lz4_compress"


### PR DESCRIPTION
This PR currently fails to create an objstore pool when the kernel fails to allocate a vdev because there are no vdev ops for the objstore type of vdev. However, the userland components appear to be working correctly:

```
delphix@pd-test:~$ sudo zpool create -o object-endpoint=foo  test2 s3 baz
No credentials location provided for objstore vdev baz
delphix@pd-test:~$ sudo zpool create -o object-credentials-location=bar test2 s3 baz
No endpoint provided for objstore vdev baz
delphix@pd-test:~$ sudo zpool create -o object-endpoint=foo -o object-credentials-location=bar test2 s3
invalid vdev specification: 's3' requires a parameter
delphix@pd-test:~$ sudo zpool create -o object-endpoint=foo -o object-credentials-location=bar test2 s3 baz
cannot create 'test2': invalid argument for this pool operation
```