### PR TITLE
Change credentials file format to just be "<access-key-id>:<secret-access-key>"

### DIFF
--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -167,22 +167,12 @@ impl Server {
     }
 
     fn get_credentials(nvl: &nvpair::NvListRef) -> Credentials {
-        let mut access_key_id = "";
-        let mut secret_access_key = "";
+        // credentials should be <access-key-id>:<secret-access-key>
+        let credential_str = nvl.lookup_string("credentials").unwrap();
+        let mut iter = credential_str.to_str().unwrap().split(":");
+        let access_key_id = iter.next().unwrap().trim();
+        let secret_access_key = iter.next().unwrap().trim();
 
-        let credentials = nvl.lookup_string("credentials").unwrap();
-        for line in credentials.to_str().unwrap().lines() {
-            if !line.starts_with("#") {
-                let mut iter = line.split("=");
-                let name = iter.next().unwrap().trim().to_lowercase();
-                let value = iter.next().unwrap().trim();
-                if name.eq("objectstore-access-key-id") {
-                    access_key_id = value;
-                } else if name.eq("objectstore-secret-access-key") {
-                    secret_access_key = value;
-                }
-            }
-        }
         let credentials = Credentials::new(
             Some(access_key_id),
             Some(secret_access_key),


### PR DESCRIPTION
```
root@mj-agent:/export/home/delphix/zfs/cmd/zfs_object_agent# cat /etc/zpool_credentials
<access-id>:<secret-key>
root@mj-agent:/export/home/delphix/zfs/cmd/zfs_object_agent# zpool create -o object-endpoint=https://s3-us-west-2.amazonaws.com  -o object-region=us-west-2  -o object-credentials-location=file:///etc/zpool_credentials  domain0 s3 cloudburst-data-2
root@mj-agent:/export/home/delphix/zfs/cmd/zfs_object_agent#
```