### PR TITLE
DLPX-75168 zed core detected during automated tests

### DIFF
--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -4,7 +4,8 @@ Documentation=man:zed(8)
 ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
-ExecStart=/usr/sbin/zed -F
+# DLPX-75168 -- to avoid zed crashes we run with jobs set to 1
+ExecStart=/usr/sbin/zed -F -j 1
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
### Motivation and Context
We are still encountering ZED crashes in automated testing from master. While we wait for upstream to resolve the issue (PR-11965), this PR will deploy a simple work-around.

### Description
Change the `zfs-zed` service so that it launches with jobs capped to 1 so that it is not possible to encounter the race that leads to ZED crashing.  This effectively has the same behavior as before async zedlet execution was introduced.

### How Has This Been Tested?
ab-pre-push:   http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5147/

Confirmed from image built from ab-pre-push result that ZED is running with -j 1
```
delphix@ip-10-110-246-215:~$ ps aux | grep zed
root      1836  0.0  0.0 201064  3196 ?        Ssl  22:37   0:00 /usr/sbin/zed -F -j 1
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
