### PR TITLE
object cache; freeing low water

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -630,6 +630,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1616,8 @@ dependencies = [
  "bincode",
  "futures",
  "futures-core",
+ "lazy_static",
+ "lru",
  "nvpair",
  "rand",
  "rust-s3",

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -17,6 +17,8 @@ async-stream = "0.3.0"
 bincode = "1.3.2"
 futures = "0.3.13"
 futures-core = "0.3.13"
+lazy_static = "1.4.0"
+lru = "0.6.5"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rust-s3 = "0.27.0-rc1"

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -1,8 +1,26 @@
 use core::time::Duration;
+use lazy_static::lazy_static;
+use lru::LruCache;
 use s3::bucket::Bucket;
+use std::collections::HashMap;
 use std::env;
 use std::fs;
+use std::sync::Arc;
 use std::time::Instant;
+use tokio::sync::Semaphore;
+
+struct ObjectCache {
+    // XXX cache key should include Bucket
+    cache: LruCache<String, Arc<Vec<u8>>>,
+    reading: HashMap<String, Arc<Semaphore>>,
+}
+
+lazy_static! {
+    static ref CACHE: std::sync::Mutex<ObjectCache> = std::sync::Mutex::new(ObjectCache {
+        cache: LruCache::new(100),
+        reading: HashMap::new(),
+    });
+}
 
 /// For testing, prefix all object keys with this string.
 /// Should be something like "username-vmname"
@@ -17,7 +35,7 @@ pub fn prefixed(key: &str) -> String {
     format!("{}/{}", prefix, key)
 }
 
-pub async fn get_object(bucket: &Bucket, key: &str) -> Vec<u8> {
+async fn get_object_impl(bucket: &Bucket, key: &str) -> Vec<u8> {
     let prefixed_key = prefixed(key);
     println!("getting {}", prefixed_key);
     let begin = Instant::now();
@@ -49,9 +67,69 @@ pub async fn get_object(bucket: &Bucket, key: &str) -> Vec<u8> {
     data
 }
 
+pub async fn get_object(bucket: &Bucket, key: &str) -> Arc<Vec<u8>> {
+    // XXX restructure so that this block "returns" an async func that does the
+    // 2nd half?
+    loop {
+        let mysem;
+        let reader;
+        // need this block separate so that we can drop the mutex before the .await
+        // note: the compiler doesn't realize that drop(c) actually drops it
+        {
+            let mut c = CACHE.lock().unwrap();
+            let mykey = key.to_string();
+            match c.cache.get(&mykey) {
+                Some(v) => {
+                    println!("found {} in cache", key);
+                    return v.clone();
+                }
+                None => match c.reading.get(key) {
+                    None => {
+                        mysem = Arc::new(Semaphore::new(0));
+                        c.reading.insert(mykey, mysem.clone());
+                        reader = true;
+                    }
+                    Some(sem) => {
+                        println!("found {} read in progress", key);
+                        mysem = sem.clone();
+                        reader = false;
+                    }
+                },
+            }
+        }
+        if reader {
+            let v = Arc::new(get_object_impl(bucket, key).await);
+            let mut c = CACHE.lock().unwrap();
+            mysem.close();
+            c.cache.put(key.to_string(), v.clone());
+            c.reading.remove(key);
+            return v;
+        } else {
+            let res = mysem.acquire().await;
+            assert!(res.is_err());
+            // XXX restructure so that new value is sent via tokio::sync::watch,
+            // so we don't have to look up in the cache again?  although this
+            // case is uncommon
+        }
+    }
+}
+
+// XXX update to take the actual Vec so that we can cache it?  Although that
+// should be the uncommon case.
 pub async fn put_object(bucket: &Bucket, key: &str, data: &[u8]) {
     let prefixed_key = prefixed(key);
     println!("putting {}", prefixed_key);
+
+    // invalidate cache
+    {
+        let mut c = CACHE.lock().unwrap();
+        let mykey = key.to_string();
+        if c.cache.contains(&mykey) {
+            println!("found {} in cache when putting - invalidating", key);
+            c.cache.put(mykey, Arc::new(data.to_vec()));
+        }
+    }
+
     let begin = Instant::now();
     loop {
         let (_, code) = bucket.put_object(&prefixed_key, data).await.unwrap();

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -58,6 +58,8 @@ impl Server {
                         // while in the middle of a end_txg(). So we only do it
                         // while there are writes in progress, which can't be
                         // the case during an end_txg().
+                        // XXX we should also be able to time out and flush even
+                        // if we are getting lots of reads.
                         if server.pool.is_some()
                             && *server.num_outstanding_writes.lock().unwrap() > 0
                         {


### PR DESCRIPTION
Add a small cache of recently read objects.

Make background freeing stop when we reach the low water mark (0.5% of blocks are pending frees).  Process objects with pending frees in order of how many pending frees they have.