### PR TITLE
no zil

### DIFF
--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -2905,6 +2905,9 @@ zil_commit_itx_assign(zilog_t *zilog, zil_commit_waiter_t *zcw)
 void
 zil_commit(zilog_t *zilog, uint64_t foid)
 {
+	// XXX ZIL can not be on object store, because writes not allowed
+	// outside syncing context.
+	return;
 	/*
 	 * We should never attempt to call zil_commit on a snapshot for
 	 * a couple of reasons:


### PR DESCRIPTION
Disable the ZIL.  The ZIL does writes (and overwrites) in contexts that the Agent does not support (e.g. outside of a txg sync).  If we want to support slog-less object storage pools, we'll need to do some more design work.  We might be better off forcing `sync=disabled` or forcing a txg sync to do sync writes.