### PR TITLE
Split into client, server and common code

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -612,6 +612,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
+name = "libzoa"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "bincode",
+ "futures",
+ "futures-core",
+ "lazy_static",
+ "lru",
+ "nvpair",
+ "rand",
+ "rust-s3",
+ "serde",
+ "tokio",
+ "tokio-pipe",
+ "tokio-stream",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1636,27 @@ dependencies = [
  "futures",
  "futures-core",
  "lazy_static",
+ "libzoa",
+ "lru",
+ "nvpair",
+ "rand",
+ "rust-s3",
+ "serde",
+ "tokio",
+ "tokio-pipe",
+ "tokio-stream",
+]
+
+[[package]]
+name = "zoa_test"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "bincode",
+ "futures",
+ "futures-core",
+ "lazy_static",
+ "libzoa",
  "lru",
  "nvpair",
  "rand",

--- a/cmd/zfs_object_agent/Makefile.am
+++ b/cmd/zfs_object_agent/Makefile.am
@@ -1,11 +1,16 @@
-sbin_PROGRAMS = target/@RUSTDIR@/zfs_object_agent
+sbin_PROGRAMS = target/@RUSTDIR@/zfs_object_agent \
+	target/@RUSTDIR@/zoa_test
 
-.PHONY: target/@RUSTDIR@/zfs_object_agent$(EXEEXT)
+.PHONY: target/@RUSTDIR@/zfs_object_agent$(EXEEXT) \
+	target/@RUSTDIR@/zoa_test$(EXEEXT)
 
 target/@RUSTDIR@/zfs_object_agent$(EXEEXT):
-	cargo build $(RUSTFLAGS)
+	cargo build --workspace $(RUSTFLAGS)
+
+target/@RUSTDIR@/zoa_test$(EXEEXT):
+	cargo build --workspace $(RUSTFLAGS)
 
 all: build
 
 build:
-	cargo build $(RUSTFLAGS)
+	cargo build --workspace $(RUSTFLAGS)

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -1,16 +1,10 @@
 [package]
-name = "libzoa"
+name = "zoa_test"
 version = "0.1.0"
 authors = ["Matthew Ahrens <mahrens@delphix.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"
 
 [dependencies]
 async-stream = "0.3.0"
@@ -26,9 +20,4 @@ serde = { version = "1.0.125", features = ["derive"] }
 tokio = { version = "1.4", features = ["full"] }
 tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"
-
-[workspace]
-members = [
-    "server",
-    "client"
-]
+libzoa = { path = "../", version = "0.1.0"  }

--- a/cmd/zfs_object_agent/client/src/client.rs
+++ b/cmd/zfs_object_agent/client/src/client.rs
@@ -1,4 +1,4 @@
-use crate::pool::*;
+use libzoa::pool::*;
 use nvpair::NvEncoding;
 use nvpair::NvList;
 use nvpair::NvListRef;

--- a/cmd/zfs_object_agent/server/Cargo.toml
+++ b/cmd/zfs_object_agent/server/Cargo.toml
@@ -1,16 +1,10 @@
 [package]
-name = "libzoa"
+name = "zfs_object_agent"
 version = "0.1.0"
 authors = ["Matthew Ahrens <mahrens@delphix.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"
 
 [dependencies]
 async-stream = "0.3.0"
@@ -26,9 +20,4 @@ serde = { version = "1.0.125", features = ["derive"] }
 tokio = { version = "1.4", features = ["full"] }
 tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"
-
-[workspace]
-members = [
-    "server",
-    "client"
-]
+libzoa = { path = "../", version = "0.1.0"  }

--- a/cmd/zfs_object_agent/server/src/main.rs
+++ b/cmd/zfs_object_agent/server/src/main.rs
@@ -1,0 +1,4 @@
+#[tokio::main]
+async fn main() {
+    libzoa::server::do_server().await;
+}

--- a/cmd/zfs_object_agent/src/lib.rs
+++ b/cmd/zfs_object_agent/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod object_access;
+pub mod object_based_log;
+pub mod pool;
+pub mod server;


### PR DESCRIPTION
I pulled out the client and server code into bin packages and left the common code in the root crate.
The agent binary continues to be `/sbin/zfs_object_agent`. The client is `/sbin/zoa_test`.