### PR TITLE
systemd service for zfs-object-agent 

### DIFF
--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -20,4 +20,4 @@ serde = { version = "1.0.125", features = ["derive"] }
 tokio = { version = "1.4", features = ["full"] }
 tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"
-libzoa = { path = "../", version = "0.1.0"  }
+libzoa = { path = "../" }

--- a/cmd/zfs_object_agent/server/Cargo.toml
+++ b/cmd/zfs_object_agent/server/Cargo.toml
@@ -20,4 +20,4 @@ serde = { version = "1.0.125", features = ["derive"] }
 tokio = { version = "1.4", features = ["full"] }
 tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"
-libzoa = { path = "../", version = "0.1.0"  }
+libzoa = { path = "../" }

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -28,7 +28,13 @@ pub fn prefixed(key: &str) -> String {
     let prefix = match env::var("AWS_PREFIX") {
         Ok(val) => val,
         Err(_) => {
-            let raw_id = fs::read_to_string("/etc/machine-id").unwrap_or(env::var("USER").unwrap());
+            let raw_id = match fs::read_to_string("/etc/machine-id") {
+                Ok(machineid) => machineid,
+                Err(_) => env::var("USER").expect(
+                    "environment variable AWS_PREFIX or USER must be set \
+                    or file /etc/machine-id should be present",
+                ),
+            };
             raw_id[..std::cmp::min(10, raw_id.len())].to_string()
         }
     };

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -6,6 +6,7 @@ lib/systemd/system/zfs-import-cache.service
 lib/systemd/system/zfs.target
 lib/systemd/system/zfs-import.service
 lib/systemd/system/zfs-import.target
+lib/systemd/system/zfs-object-agent.service
 lib/systemd/system/zfs-volume-wait.service
 lib/systemd/system/zfs-volumes.target
 lib/systemd/system-preset/

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -12,6 +12,7 @@ systemdunit_DATA = \
 	zfs-volume-wait.service \
 	zfs-import.target \
 	zfs-volumes.target \
+	zfs-object-agent.service \
 	zfs.target
 
 SUBSTFILES += $(systemdpreset_DATA) $(systemdunit_DATA)

--- a/etc/systemd/system/zfs-object-agent.service.in
+++ b/etc/systemd/system/zfs-object-agent.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=ZFS object agent
+After=local-fs.target
+Before=zfs-import-cache.service
+
+[Service]
+Environment="RUST_BACKTRACE=1"
+ExecStart=/sbin/zfs_object_agent
+Restart=on-abort
+
+[Install]
+WantedBy=zfs-import.target

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -350,7 +350,7 @@ image which is ZFS aware.
 
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
-    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target
+    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target zfs-object-agent.service
 %else
     %define systemd --enable-sysvinit --disable-systemd
 %endif


### PR DESCRIPTION
When started as a service the agent would find the env variable USER unset and panic (even when the file /etc/machine-id was present). Fixed it to look at USER only if AWS_PREFIX is unset and machine-id is unavailable.


```
delphix@mj-agent:~$ systemctl list-unit-files | grep zfs
zfs-import-cache.service               enabled        
zfs-import-scan.service                disabled       
zfs-import.service                     masked         
zfs-mount.service                      enabled        
zfs-object-agent.service               disabled       <-----------
zfs-share.service                      enabled        
zfs-volume-wait.service                enabled        
zfs-zed.service                        enabled        
zfs-import.target                      enabled        
zfs-volumes.target                     enabled        
zfs.target                             enabled        
delphix@mj-agent:~$ sudo systemctl enable zfs-object-agent.service
Created symlink /etc/systemd/system/zfs-import.target.wants/zfs-object-agent.service → /lib/systemd/system/zfs-object-agent.service.
delphix@mj-agent:~$ sudo systemctl start zfs-object-agent.service
delphix@mj-agent:~$ sudo systemctl status zfs-object-agent.service
● zfs-object-agent.service - ZFS object agent
   Loaded: loaded (/lib/systemd/system/zfs-object-agent.service; enabled; vendor preset: enabled)
   Active: active (running) since Sun 2021-05-02 22:14:03 UTC; 3s ago
 Main PID: 5287 (zfs_object_agen)
    Tasks: 3 (limit: 8842)
   CGroup: /system.slice/zfs-object-agent.service
           └─5287 /sbin/zfs_object_agent

May 02 22:14:03 mj-agent.dcol2 systemd[1]: Started ZFS object agent.
May 02 22:14:03 mj-agent.dcol2 zfs_object_agent[5287]: Listening on: /run/zfs_socket
delphix@mj-agent:~$ 


delphix@mj-agent:~$ sudo zpool create -o object-endpoint=https://s3-us-west-2.amazonaws.com  -o object-region=us-west-2  -o object-credentials-location=file:///etc/zpool_credentials  domain0 s3 cloudburst-data-2
delphix@mj-agent:~$ echo $?
0
delphix@mj-agent:~$ zpool list
NAME      SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
domain0   512P      0   512P        -         -     0%     0%  1.00x    ONLINE  -
rpool    69.5G  16.0G  53.5G        -         -      -    23%  1.00x    ONLINE  -
delphix@mj-agent:~$ 
```