### PR TITLE
object consolidation

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -1653,6 +1653,7 @@ dependencies = [
  "rand",
  "rust-s3",
  "serde",
+ "stream-reduce",
  "tokio",
  "tokio-pipe",
  "tokio-stream",

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -627,7 +627,6 @@ dependencies = [
  "serde",
  "stream-reduce",
  "tokio",
- "tokio-pipe",
  "tokio-stream",
 ]
 
@@ -1381,16 +1380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-pipe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ffd0cce0950fbb0807ad67e22c3724c6cf3ea6c0a235b740c4a3e54d4a6977"
-dependencies = [
- "libc",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,39 +1631,19 @@ checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 name = "zfs_object_agent"
 version = "0.1.0"
 dependencies = [
- "async-stream",
- "bincode",
- "futures",
- "futures-core",
- "lazy_static",
  "libzoa",
- "lru",
- "nvpair",
- "rand",
- "rust-s3",
- "serde",
- "stream-reduce",
  "tokio",
- "tokio-pipe",
- "tokio-stream",
 ]
 
 [[package]]
 name = "zoa_test"
 version = "0.1.0"
 dependencies = [
- "async-stream",
- "bincode",
  "futures",
- "futures-core",
- "lazy_static",
  "libzoa",
- "lru",
  "nvpair",
  "rand",
  "rust-s3",
  "serde",
  "tokio",
- "tokio-pipe",
- "tokio-stream",
 ]

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "rand",
  "rust-s3",
  "serde",
+ "stream-reduce",
  "tokio",
  "tokio-pipe",
  "tokio-stream",
@@ -1250,6 +1251,16 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "stream-reduce"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47049626a7bcf00214826ee7860dfd5723dbda9d7238679a18e8f817afafc58e"
+dependencies = [
+ "futures",
+ "pin-utils",
 ]
 
 [[package]]

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzoa"
 version = "0.1.0"
-authors = ["Matthew Ahrens <mahrens@delphix.com>"]
+authors = ["Delphix"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -25,7 +25,6 @@ rust-s3 = "0.27.0-rc1"
 serde = { version = "1.0.125", features = ["derive"] }
 stream-reduce = "0.1.0"
 tokio = { version = "1.4", features = ["full"] }
-tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"
 
 [workspace]

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -23,6 +23,7 @@ nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rust-s3 = "0.27.0-rc1"
 serde = { version = "1.0.125", features = ["derive"] }
+stream-reduce = "0.1.0"
 tokio = { version = "1.4", features = ["full"] }
 tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -7,17 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-stream = "0.3.0"
-bincode = "1.3.2"
 futures = "0.3.13"
-futures-core = "0.3.13"
-lazy_static = "1.4.0"
-lru = "0.6.5"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rust-s3 = "0.27.0-rc1"
 serde = { version = "1.0.125", features = ["derive"] }
 tokio = { version = "1.4", features = ["full"] }
-tokio-pipe = "0.2.1"
-tokio-stream = "0.1.5"
 libzoa = { path = "../" }

--- a/cmd/zfs_object_agent/client/src/main.rs
+++ b/cmd/zfs_object_agent/client/src/main.rs
@@ -364,7 +364,8 @@ fn do_nvpair() {
     write_file_as_bytes("./zpool.cache.rust", &newbuf);
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     // assumes that AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
@@ -377,27 +378,20 @@ fn main() {
     let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
     println!("bucket: {:?}", bucket);
 
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .thread_name("zoa")
-        .build()
-        .unwrap()
-        .block_on(async move {
-            match &args[1][..] {
-                "s3" => do_s3(&bucket).await.unwrap(),
-                "list" => do_list(&bucket).await.unwrap(),
-                "delete" => do_delete(&bucket).await.unwrap(),
-                "obl" => do_obl(&bucket).await.unwrap(),
-                "create" => do_create().await.unwrap(),
-                "write" => do_write().await.unwrap(),
-                "read" => do_read().await.unwrap(),
-                "free" => do_free().await.unwrap(),
-                "btree" => do_btree(),
-                "nvpair" => do_nvpair(),
+    match &args[1][..] {
+        "s3" => do_s3(&bucket).await.unwrap(),
+        "list" => do_list(&bucket).await.unwrap(),
+        "delete" => do_delete(&bucket).await.unwrap(),
+        "obl" => do_obl(&bucket).await.unwrap(),
+        "create" => do_create().await.unwrap(),
+        "write" => do_write().await.unwrap(),
+        "read" => do_read().await.unwrap(),
+        "free" => do_free().await.unwrap(),
+        "btree" => do_btree(),
+        "nvpair" => do_nvpair(),
 
-                _ => {
-                    println!("invalid argument: {}", args[1]);
-                }
-            }
-        });
+        _ => {
+            println!("invalid argument: {}", args[1]);
+        }
+    }
 }

--- a/cmd/zfs_object_agent/client/src/main.rs
+++ b/cmd/zfs_object_agent/client/src/main.rs
@@ -364,8 +364,7 @@ fn do_nvpair() {
     write_file_as_bytes("./zpool.cache.rust", &newbuf);
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args: Vec<String> = std::env::args().collect();
 
     // assumes that AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
@@ -378,20 +377,27 @@ async fn main() {
     let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
     println!("bucket: {:?}", bucket);
 
-    match &args[1][..] {
-        "s3" => do_s3(&bucket).await.unwrap(),
-        "list" => do_list(&bucket).await.unwrap(),
-        "delete" => do_delete(&bucket).await.unwrap(),
-        "obl" => do_obl(&bucket).await.unwrap(),
-        "create" => do_create().await.unwrap(),
-        "write" => do_write().await.unwrap(),
-        "read" => do_read().await.unwrap(),
-        "free" => do_free().await.unwrap(),
-        "btree" => do_btree(),
-        "nvpair" => do_nvpair(),
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("zoa")
+        .build()
+        .unwrap()
+        .block_on(async move {
+            match &args[1][..] {
+                "s3" => do_s3(&bucket).await.unwrap(),
+                "list" => do_list(&bucket).await.unwrap(),
+                "delete" => do_delete(&bucket).await.unwrap(),
+                "obl" => do_obl(&bucket).await.unwrap(),
+                "create" => do_create().await.unwrap(),
+                "write" => do_write().await.unwrap(),
+                "read" => do_read().await.unwrap(),
+                "free" => do_free().await.unwrap(),
+                "btree" => do_btree(),
+                "nvpair" => do_nvpair(),
 
-        _ => {
-            println!("invalid argument: {}", args[1]);
-        }
-    }
+                _ => {
+                    println!("invalid argument: {}", args[1]);
+                }
+            }
+        });
 }

--- a/cmd/zfs_object_agent/server/Cargo.toml
+++ b/cmd/zfs_object_agent/server/Cargo.toml
@@ -17,6 +17,7 @@ nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rust-s3 = "0.27.0-rc1"
 serde = { version = "1.0.125", features = ["derive"] }
+stream-reduce = "0.1.0"
 tokio = { version = "1.4", features = ["full"] }
 tokio-pipe = "0.2.1"
 tokio-stream = "0.1.5"

--- a/cmd/zfs_object_agent/server/Cargo.toml
+++ b/cmd/zfs_object_agent/server/Cargo.toml
@@ -1,24 +1,11 @@
 [package]
 name = "zfs_object_agent"
 version = "0.1.0"
-authors = ["Matthew Ahrens <mahrens@delphix.com>"]
+authors = ["Delphix"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-stream = "0.3.0"
-bincode = "1.3.2"
-futures = "0.3.13"
-futures-core = "0.3.13"
-lazy_static = "1.4.0"
-lru = "0.6.5"
-nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
-rand = "0.8.3"
-rust-s3 = "0.27.0-rc1"
-serde = { version = "1.0.125", features = ["derive"] }
-stream-reduce = "0.1.0"
 tokio = { version = "1.4", features = ["full"] }
-tokio-pipe = "0.2.1"
-tokio-stream = "0.1.5"
 libzoa = { path = "../" }

--- a/cmd/zfs_object_agent/server/src/main.rs
+++ b/cmd/zfs_object_agent/server/src/main.rs
@@ -1,4 +1,10 @@
-#[tokio::main]
-async fn main() {
-    libzoa::server::do_server().await;
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("zoa")
+        .build()
+        .unwrap()
+        .block_on(async move {
+            libzoa::server::do_server().await;
+        });
 }

--- a/cmd/zfs_object_agent/src/lib.rs
+++ b/cmd/zfs_object_agent/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod object_access;
 pub mod object_based_log;
+pub mod object_block_map;
 pub mod pool;
 pub mod server;

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -246,37 +246,12 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         entries
     }
 
-    pub fn iterate(&self) -> impl Stream<Item = T> {
-        self.iterate_after(0)
-        /*
-        let mut stream = FuturesOrdered::new();
-        let generation = self.generation;
-        for chunk in 0..self.num_chunks {
-            let pool = self.pool.clone();
-            let n = self.name.clone();
-            let fut = async move {
-                async move { ObjectBasedLogChunk::get(&pool.bucket, &n, generation, chunk).await }
-            };
-            stream.push(fut);
-        }
-        // Note: buffered() is needed because rust-s3 creates one connection for
-        // each request, rather than using a connection pool. If we created 1000
-        // connections we'd run into the open file descriptor limit.
-        let mut buffered_stream = stream.buffered(50);
-        stream! {
-            while let Some(fut) = buffered_stream.next().await {
-                let chunk = fut;
-                println!("yielding entries of chunk {}", chunk.chunk);
-                for ent in chunk.entries {
-                    yield ent;
-                }
-            }
-        }
-        */
-    }
-
     pub fn num_chunks(&self) -> u64 {
         self.num_chunks
+    }
+
+    pub fn iterate(&self) -> impl Stream<Item = T> {
+        self.iterate_after(0)
     }
 
     pub fn iterate_after(&self, first_chunk: u64) -> impl Stream<Item = T> {

--- a/cmd/zfs_object_agent/src/object_block_map.rs
+++ b/cmd/zfs_object_agent/src/object_block_map.rs
@@ -1,0 +1,110 @@
+use crate::pool::*;
+use std::borrow::Borrow;
+use std::collections::BTreeSet;
+use std::ops::Bound::*;
+
+#[derive(Debug)]
+pub struct ObjectBlockMap {
+    map: BTreeSet<ObjectBlockMapEntry>,
+}
+
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Copy, Clone)]
+struct ObjectBlockMapEntry {
+    obj: OBMEObject,
+    block: OBMEBlock,
+}
+
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Copy, Clone)]
+struct OBMEObject(ObjectID);
+
+impl Borrow<OBMEObject> for ObjectBlockMapEntry {
+    fn borrow(&self) -> &OBMEObject {
+        &self.obj
+    }
+}
+#[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Copy, Clone)]
+struct OBMEBlock(BlockID);
+
+impl Borrow<OBMEBlock> for ObjectBlockMapEntry {
+    fn borrow(&self) -> &OBMEBlock {
+        &self.block
+    }
+}
+
+impl ObjectBlockMap {
+    pub fn new() -> Self {
+        ObjectBlockMap {
+            map: BTreeSet::new(),
+        }
+    }
+
+    pub fn verify(&self) {
+        let mut prev_ent_opt: Option<ObjectBlockMapEntry> = None;
+        for ent in self.map.iter() {
+            if let Some(prev_ent) = prev_ent_opt {
+                assert!(ent.obj > prev_ent.obj);
+                assert!(ent.block > prev_ent.block);
+            }
+            prev_ent_opt = Some(*ent);
+        }
+    }
+
+    pub fn insert(&mut self, obj: ObjectID, block: BlockID) {
+        // verify that this block is between the existing entries blocks
+        let prev_ent_opt = self
+            .map
+            .range((Unbounded, Excluded(OBMEObject(obj))))
+            .next_back();
+        if let Some(prev_ent) = prev_ent_opt {
+            assert!(prev_ent.block.0 < block);
+        }
+        let next_ent_opt = self
+            .map
+            .range((Excluded(OBMEObject(obj)), Unbounded))
+            .next();
+        if let Some(next_ent) = next_ent_opt {
+            assert!(next_ent.block.0 > block);
+        }
+        // verify that this object is not yet in the map
+        assert!(!self.map.contains(&OBMEObject(obj)));
+
+        self.map.insert(ObjectBlockMapEntry {
+            obj: OBMEObject(obj),
+            block: OBMEBlock(block),
+        });
+    }
+
+    pub fn remove(&mut self, obj: ObjectID) {
+        let removed = self.map.remove(&OBMEObject(obj));
+        assert!(removed);
+    }
+
+    pub fn block_to_obj(&self, block: BlockID) -> ObjectID {
+        self.map
+            .range((Unbounded, Included(OBMEBlock(block))))
+            .next_back()
+            .unwrap()
+            .obj
+            .0
+    }
+
+    pub fn obj_to_block(&self, obj: ObjectID) -> BlockID {
+        self.map.get(&OBMEObject(obj)).unwrap().block.0
+    }
+
+    pub fn last_obj(&self) -> ObjectID {
+        self.map
+            .iter()
+            .next_back()
+            .unwrap_or(&ObjectBlockMapEntry {
+                obj: OBMEObject(ObjectID(0)),
+                block: OBMEBlock(BlockID(0)),
+            })
+            .obj
+            .0
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -252,7 +252,6 @@ pub struct PoolState {
     // thread.
     syncing_state: tokio::sync::Mutex<PoolSyncingState>,
 
-    //block_to_obj: std::sync::RwLock<BTreeMap<BlockID, ObjectID>>,
     block_to_obj: std::sync::RwLock<ObjectBlockMap>,
 
     pub readonly_state: Arc<PoolSharedState>,
@@ -312,26 +311,9 @@ struct ReclaimFreesComplete {
     freed_blocks_bytes: u64,
     num_chunks: u64,
     remaining_frees: Vec<PendingFreesLogEntry>,
-    // XXX include deleted objects' firstblockid, so we can properly remove it from the obj mapping
     rewritten_object_sizes: Vec<(ObjectID, u32)>,
     deleted_objects: Vec<ObjectID>,
 }
-
-/*
-impl PoolState {
-    fn block_to_object(&self, block: BlockID) -> ObjectID {
-        // find entry equal or less than this blockID
-        *self
-            .block_to_obj
-            .read()
-            .unwrap()
-            .range((Unbounded, Included(block)))
-            .next_back()
-            .unwrap()
-            .1
-    }
-}
-*/
 
 impl Pool {
     pub async fn create(bucket: &Bucket, name: &str, guid: PoolGUID) {

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -129,8 +129,8 @@ impl Server {
                     "free block" => {
                         println!("got request: {:?}", nvl);
                         let block = BlockID(nvl.lookup_uint64("block").unwrap());
-                        let _size = nvl.lookup_uint64("size").unwrap();
-                        server.free_block(block);
+                        let size = nvl.lookup_uint64("size").unwrap();
+                        server.free_block(block, size as u32);
                     }
                     "read block" => {
                         println!("got request: {:?}", nvl);
@@ -275,8 +275,8 @@ impl Server {
     }
 
     /// initiate free.  No response.  Does not block.  Completes when the current txg is ended.
-    fn free_block(&mut self, block: BlockID) {
-        self.pool.as_mut().unwrap().free_block(block);
+    fn free_block(&mut self, block: BlockID, size: u32) {
+        self.pool.as_mut().unwrap().free_block(block, size);
     }
 
     /// initiate read, sends response when completed.  Does not block.

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -3729,7 +3729,8 @@ zpool_do_import(int argc, char **argv)
 	idata.cachefile = cachefile;
 	idata.scan = do_scan;
 	idata.policy = policy;
-	idata.handle_creds = (int (*)(void *, nvlist_t *, char *))zpool_get_objstore_credentials;
+	idata.handle_creds =
+	    (int (*)(void *, nvlist_t *, char *))zpool_get_objstore_credentials;
 
 	pools = zpool_search_import(g_zfs, &idata, &libzfs_config_ops);
 

--- a/lib/libzutil/zutil_import.c
+++ b/lib/libzutil/zutil_import.c
@@ -1431,7 +1431,7 @@ copy_creds(nvlist_t *src, nvlist_t *dst)
 
 	tree = fnvlist_lookup_nvlist(src, ZPOOL_CONFIG_VDEV_TREE);
 	dsttree = fnvlist_lookup_nvlist(dst, ZPOOL_CONFIG_VDEV_TREE);
-	
+
 	if (nvlist_lookup_nvlist_array(tree, ZPOOL_CONFIG_CHILDREN,
 	    &child, &children) != 0) {
 		return;
@@ -1456,17 +1456,17 @@ copy_creds(nvlist_t *src, nvlist_t *dst)
 		guid = fnvlist_lookup_uint64(child[c], ZPOOL_CONFIG_GUID);
 
 		for (c2 = 0; c2 < dstchildren; c2++) {
-			if (nvlist_lookup_string(dstchild[c2], ZPOOL_CONFIG_TYPE,
-				&type) != 0) {
+			if (nvlist_lookup_string(dstchild[c2],
+			    ZPOOL_CONFIG_TYPE, &type) != 0) {
 				continue;
 			}
-			
+
 			if (strcmp(type, VDEV_TYPE_OBJSTORE) != 0 ||
 			    fnvlist_lookup_uint64(dstchild[c2],
 			    ZPOOL_CONFIG_GUID) != guid) {
 				continue;
 			}
-			
+
 			fnvlist_add_string(dstchild[c2],
 			    ZPOOL_CONFIG_OBJSTORE_CREDENTIALS, creds);
 			break;
@@ -1642,46 +1642,49 @@ zpool_find_import_cached(libpc_handle_t *hdl, importargs_t *iarg)
 		nvlist_t *tree;
 		uint_t c, children;
 		nvlist_t **child;
-		
+
 		tree = fnvlist_lookup_nvlist(src, ZPOOL_CONFIG_VDEV_TREE);
-		
+
 		if (nvlist_lookup_nvlist_array(tree, ZPOOL_CONFIG_CHILDREN,
-			&child, &children) != 0) {
+		    &child, &children) != 0) {
 			fprintf(stderr, gettext("cannot import '%s': invalid "
 			    "configuration detected.\n"), name);
 			goto errout;
 		}
-		
+
 		for (c = 0; c < children; c++) {
 			char *type, *creds;
 			if (nvlist_lookup_string(child[c], ZPOOL_CONFIG_TYPE,
-				&type) != 0) {
-				fprintf(stderr, gettext("cannot import '%s': invalid "
+			    &type) != 0) {
+				fprintf(stderr, gettext(
+				    "cannot import '%s': invalid "
 				    "configuration detected.\n"), name);
 				goto errout;
 			}
-			
+
 			if (strcmp(type, VDEV_TYPE_OBJSTORE) != 0)
 				continue;
-			
+
 			if ((nvlist_lookup_string(child[c],
 			    "object-credentials-location",
 			    &creds)) != 0) {
-				fprintf(stderr, gettext("cannot import '%s': No "
-				    "objstore credentials located.\n"), name);
+				fprintf(stderr, gettext("cannot import '%s': "
+				    "No objstore credentials located.\n"),
+				    name);
 				goto errout;
 			}
-			
+
 			if (iarg->handle_creds(hdl->lpc_lib_handle, child[c],
-				creds) != 0) {
-				fprintf(stderr, gettext("cannot import '%s': Failed to "
+			    creds) != 0) {
+				fprintf(stderr, gettext("cannot import '%s': "
+				    "Failed to "
 				    "retrieve objstore credentials.\n"), name);
 				goto errout;
 			}
-			
+
 			break;
 		}
-		
+
 		if ((dst = zutil_refresh_config(hdl, src)) == NULL)
 			goto errout;
 

--- a/module/os/linux/zfs/vdev_object_store.c
+++ b/module/os/linux/zfs/vdev_object_store.c
@@ -460,15 +460,17 @@ agent_reader(void *arg)
 			uint8_t *arr;
 			int err = nvlist_lookup_uint8_array(nv, AGENT_UBERBLOCK,
 			    &arr, &len);
-			ASSERT3U (len, ==, sizeof (uberblock_t));
-			if (err == 0)
+			if (err == 0) {
+				ASSERT3U(len, ==, sizeof (uberblock_t));
 				bcopy(arr, &vos->vos_uberblock, len);
+			}
 
 			uint64_t next_block = fnvlist_lookup_uint64(nv,
 			    AGENT_NEXT_BLOCK);
 			vos->vos_next_block = next_block;
 
-			zfs_dbgmsg("got pool open done len=%llu block=%llu", len, next_block);
+			zfs_dbgmsg("got pool open done len=%llu block=%llu",
+			    len, next_block);
 
 			fnvlist_free(nv);
 			mutex_enter(&vos->vos_outstanding_lock);

--- a/module/os/linux/zfs/vdev_object_store.c
+++ b/module/os/linux/zfs/vdev_object_store.c
@@ -534,12 +534,14 @@ vdev_object_store_init(spa_t *spa, nvlist_t *nv, void **tsd)
 	} else {
 		return (SET_ERROR(EINVAL));
 	}
-	if (!nvlist_lookup_string(nv, zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS), &val)) {
+	if (!nvlist_lookup_string(nv,
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS), &val)) {
 		vos->vos_credential_location = kmem_strdup(val);
 	} else {
 		return (SET_ERROR(EINVAL));
 	}
-	if (!nvlist_lookup_string(nv, ZPOOL_CONFIG_OBJSTORE_CREDENTIALS, &val)) {
+	if (!nvlist_lookup_string(nv,
+	    ZPOOL_CONFIG_OBJSTORE_CREDENTIALS, &val)) {
 		vos->vos_credentials = kmem_strdup(val);
 	} else {
 		return (SET_ERROR(EINVAL));
@@ -737,9 +739,13 @@ vdev_object_store_config_generate(vdev_t *vd, nvlist_t *nv)
 {
 	vdev_object_store_t *vos = vd->vdev_tsd;
 
-	fnvlist_add_string(nv, zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS), vos->vos_credential_location);
-	fnvlist_add_string(nv, zpool_prop_to_name(ZPOOL_PROP_OBJ_ENDPOINT), vos->vos_endpoint);
-	fnvlist_add_string(nv, zpool_prop_to_name(ZPOOL_PROP_OBJ_REGION), vos->vos_region);
+	fnvlist_add_string(nv,
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS),
+	    vos->vos_credential_location);
+	fnvlist_add_string(nv,
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_ENDPOINT), vos->vos_endpoint);
+	fnvlist_add_string(nv,
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_REGION), vos->vos_region);
 }
 
 static void

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3629,7 +3629,7 @@ spa_ld_select_uberblock(spa_t *spa, spa_import_type_t type)
 		nvlist_free(unsup_feat);
 	}
 #endif
-	
+
 	if (type != SPA_IMPORT_ASSEMBLE && spa->spa_config_splitting) {
 		spa_config_enter(spa, SCL_ALL, FTAG, RW_WRITER);
 		spa_try_repair(spa, spa->spa_config);
@@ -3689,32 +3689,31 @@ copy_objstore_credentials(nvlist_t *src, nvlist_t *dest)
 		    &type) != 0) {
 			continue;
 		}
-		
+
 		if (strcmp(type, VDEV_TYPE_OBJSTORE) != 0)
 			continue;
-		
+
 		creds = fnvlist_lookup_string(schild[c1],
 		    ZPOOL_CONFIG_OBJSTORE_CREDENTIALS);
 		guid = fnvlist_lookup_uint64(schild[c1], ZPOOL_CONFIG_GUID);
 
 		for (int c2 = 0; c2 < dchildren; c2++) {
 			if (nvlist_lookup_string(dchild[c2], ZPOOL_CONFIG_TYPE,
-				&type) != 0) {
+			    &type) != 0) {
 				continue;
 			}
-			
+
 			if (strcmp(type, VDEV_TYPE_OBJSTORE) != 0 ||
 			    fnvlist_lookup_uint64(dchild[c2],
 			    ZPOOL_CONFIG_GUID) != guid) {
 				continue;
 			}
-			
+
 			fnvlist_add_string(dchild[c2],
 			    ZPOOL_CONFIG_OBJSTORE_CREDENTIALS, creds);
 			break;
 		}
-			
-		
+
 		break;
 	}
 }


### PR DESCRIPTION
- add new ObjectBasedLog to track object sizes
- use new accounting to consolidate small adjacent objects when freeing
- improve some existing space accounting
- object-block mapping can be addressed by either object or block (because it's sorted by both)
- reduce dependencies in cargo files
- fix cstyle errors