### PR TITLE
Try to fix existing export bug masked by no-op

### DIFF
--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -1561,7 +1561,7 @@ spa_unload(spa_t *spa)
 	 */
 	spa_async_suspend(spa);
 
-	if (spa->spa_root_vdev) {
+	if (spa->spa_root_vdev && spa->spa_final_txg == UINT64_MAX) {
 		vdev_t *root_vdev = spa->spa_root_vdev;
 		vdev_initialize_stop_all(root_vdev, VDEV_INITIALIZE_ACTIVE);
 		vdev_trim_stop_all(root_vdev, VDEV_TRIM_ACTIVE);

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1924,7 +1924,7 @@ retry:
 	if (txg > spa_freeze_txg(spa))
 		return (0);
 
-	ASSERT(txg <= spa->spa_final_txg);
+	ASSERT3U(txg, <=, spa->spa_final_txg);
 
 #ifdef _KERNEL
 	if (spa->spa_root_vdev->vdev_child[0]->vdev_ops ==


### PR DESCRIPTION
As discussed in the team meeting, we fix this issue by not attempting to redo the stop operations if they already occurred in spa_export (as determined by the spa_final_txg being set)