### PR TITLE
zed: protect against wait4()/fork() races to the global PID table

### DIFF
--- a/cmd/zed/zed_exec.c
+++ b/cmd/zed/zed_exec.c
@@ -142,8 +142,10 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 		    prog, eid, strerror(ENAMETOOLONG));
 		return;
 	}
+	(void) pthread_mutex_lock(&_launched_processes_lock);
 	pid = fork();
 	if (pid < 0) {
+		(void) pthread_mutex_unlock(&_launched_processes_lock);
 		zed_log_msg(LOG_WARNING,
 		    "Failed to fork \"%s\" for eid=%llu: %s",
 		    prog, eid, strerror(errno));
@@ -166,20 +168,19 @@ _zed_exec_fork_child(uint64_t eid, const char *dir, const char *prog,
 
 	/* parent process */
 
-	__atomic_sub_fetch(&_launched_processes_limit, 1, __ATOMIC_SEQ_CST);
-	zed_log_msg(LOG_INFO, "Invoking \"%s\" eid=%llu pid=%d",
-	    prog, eid, pid);
-
 	node = calloc(1, sizeof (*node));
 	if (node) {
 		node->pid = pid;
 		node->eid = eid;
 		node->name = strdup(prog);
 
-		(void) pthread_mutex_lock(&_launched_processes_lock);
 		avl_add(&_launched_processes, node);
-		(void) pthread_mutex_unlock(&_launched_processes_lock);
 	}
+	(void) pthread_mutex_unlock(&_launched_processes_lock);
+
+	__atomic_sub_fetch(&_launched_processes_limit, 1, __ATOMIC_SEQ_CST);
+	zed_log_msg(LOG_INFO, "Invoking \"%s\" eid=%llu pid=%d",
+	    prog, eid, pid);
 }
 
 static void


### PR DESCRIPTION
### Motivation and Context
This is for **DLPX-75168** (zed core detected during automated tests)

The first attempt to close a race introduced with the async zedlet execution feature (PR-11965, commit f9bece92e24b) did not completely eliminate the race and we are occasionally encountering zed cores in automated testing.  The upstream contributor, Ahelenia, was able to finally reproduce the crash we observed and offer a revised fix that eliminates the race.

### Description
```
    zed: protect against wait4()/fork() races to the global PID table

    This can be very easily triggered by adding a sleep(1) before
    the wait4() on a PID-starved system: the reaper thread would wait
    for a child before its entry appeared, letting old entries accumulate:

      Invoking "all-debug.sh" eid=3021 pid=391
      Finished "(null)" eid=0 pid=391 time=0.002432s exit=0
      Invoking "all-syslog.sh" eid=3021 pid=336
      Finished "(null)" eid=0 pid=336 time=0.002432s exit=0
      Invoking "history_event-zfs-list-cacher.sh" eid=3021 pid=347
      Invoking "all-debug.sh" eid=3022 pid=349
      Finished "history_event-zfs-list-cacher.sh" eid=3021 pid=347
                                                  time=0.001669s exit=0
      Finished "(null)" eid=0 pid=349 time=0.002404s exit=0
      Invoking "all-syslog.sh" eid=3022 pid=370
      Finished "(null)" eid=0 pid=370 time=0.002427s exit=0
      Invoking "history_event-zfs-list-cacher.sh" eid=3022 pid=391
      avl_find(tree, new_node, &where) == NULL
      ASSERT at ../../module/avl/avl.c:641:avl_add()
      Thread 1 "zed" received signal SIGABRT, Aborted.

    By employing this wider lock, we atomise [wait, remove] and [fork, add]:
    slowing down the reaper thread now just causes some zombies
    to accumulate until it can get to them
```

**NOTE:**  This is a clean cherry-pick merge from upstream commit [3bd6b0e05](https://github.com/openzfs/zfs/commit/3bd6b0e05)

### How Has This Been Tested?
`ab-pre-push`
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5242/

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)