### PR TITLE
ztest on an object store based zpool

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
@@ -644,9 +644,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1744,9 +1744,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1784,9 +1784,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1796,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1811,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1823,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1846,15 +1846,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/cmd/zfs_object_agent/client/src/client.rs
+++ b/cmd/zfs_object_agent/client/src/client.rs
@@ -63,13 +63,7 @@ impl Client {
     }
 
     fn get_credential_string(aws_key_id: &str, secret_key: &str) -> String {
-        let credentials = format!(
-            "objectstore-access-key-id = {} \n objectstore-secret-access-key = {} \n",
-            aws_key_id, secret_key
-        )
-        .to_string();
-
-        credentials
+        format!("{}:{}", aws_key_id, secret_key).to_string()
     }
 
     pub async fn create_pool(

--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -61,6 +61,7 @@ COMMON_H = \
 	sa.h \
 	sa_impl.h \
 	skein.h \
+	sock.h \
 	spa_boot.h \
 	spa_checkpoint.h \
 	spa_log_spacemap.h \

--- a/include/sys/sock.h
+++ b/include/sys/sock.h
@@ -1,0 +1,71 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+#ifndef _SYS_SOCK_H
+#define	_SYS_SOCK_H
+
+#include <sys/fcntl.h>
+#ifdef _KERNEL
+#include <linux/un.h>
+#include <linux/net.h>
+#else
+#include <sys/un.h>
+#include <sys/socket.h>
+#endif
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+
+#ifdef _KERNEL
+
+#define	INVALID_SOCKET (NULL)
+#define	SOCK_FMT "%px"
+
+typedef struct socket *ksocket_t;
+typedef struct kvec kvec_t;
+
+#else /* !_KERNEL */
+
+#define	INVALID_SOCKET (-1)
+#define	SOCK_FMT "%d"
+
+typedef int ksocket_t;
+typedef struct iovec kvec_t;
+
+#endif /* _KERNEL */
+
+int ksock_create(int domain, int type, int protocol, ksocket_t *sock);
+int ksock_connect(ksocket_t sock, struct sockaddr *socket_address,
+    unsigned long socklen);
+void ksock_close(ksocket_t sock);
+int ksock_shutdown(ksocket_t sock, int how);
+size_t ksock_send(ksocket_t sock, struct msghdr *msg, kvec_t *iov, int iovcnt,
+    int total_size);
+size_t ksock_receive(ksocket_t sock, struct msghdr *msg, kvec_t *iov,
+    int iovcnt, int total_size, int flags);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_SOCK_H */

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -106,6 +106,7 @@ KERNEL_C = \
 	sa.c \
 	sha256.c \
 	skein_zfs.c \
+	sock.c \
 	spa.c \
 	spa_boot.c \
 	spa_checkpoint.c \
@@ -131,6 +132,7 @@ KERNEL_C = \
 	vdev_indirect_mapping.c \
 	vdev_initialize.c \
 	vdev_label.c \
+	vdev_object_store.c \
 	vdev_mirror.c \
 	vdev_missing.c \
 	vdev_queue.c \

--- a/module/os/linux/zfs/Makefile.in
+++ b/module/os/linux/zfs/Makefile.in
@@ -17,6 +17,7 @@ $(MODULE)-objs += ../os/linux/zfs/spa_misc_os.o
 $(MODULE)-objs += ../os/linux/zfs/vdev_disk.o
 $(MODULE)-objs += ../os/linux/zfs/vdev_file.o
 $(MODULE)-objs += ../os/linux/zfs/vdev_object_store.o
+$(MODULE)-objs += ../os/linux/zfs/sock.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_acl.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_ctldir.o
 $(MODULE)-objs += ../os/linux/zfs/zfs_debug.o

--- a/module/os/linux/zfs/sock.c
+++ b/module/os/linux/zfs/sock.c
@@ -1,0 +1,112 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2021 by Delphix. All rights reserved.
+ */
+
+#include <sys/abd.h>
+#include <sys/sock.h>
+
+#ifdef _KERNEL
+int
+ksock_create(int domain, int type, int protocol, ksocket_t *sock)
+{
+	return (sock_create(domain, type, protocol, sock));
+}
+
+int
+ksock_connect(ksocket_t sock, struct sockaddr *socket_address,
+    unsigned long socklen)
+{
+	return (sock->ops->connect(sock, socket_address, socklen, 0));
+}
+
+void
+ksock_close(ksocket_t sock)
+{
+	sock_release(sock);
+}
+
+int
+ksock_shutdown(ksocket_t sock, int how)
+{
+	return (kernel_sock_shutdown(sock, how));
+}
+
+size_t
+ksock_send(ksocket_t sock, struct msghdr *msg, kvec_t *iov,
+    int iovcnt, int total_size)
+{
+	return (kernel_sendmsg(sock, msg, iov, iovcnt, total_size));
+}
+
+size_t
+ksock_receive(ksocket_t sock, struct msghdr *msg, kvec_t *iov,
+    int iovcnt, int total_size, int flags)
+{
+	return (kernel_recvmsg(sock, msg, iov, iovcnt, total_size, flags));
+}
+
+#else /* !_KERNEL */
+int
+ksock_create(int domain, int type, int protocol, ksocket_t *sock)
+{
+	*sock = socket(PF_UNIX, type, protocol);
+	if (*sock == -1) {
+		return (errno);
+	}
+	return (0);
+}
+
+int
+ksock_connect(ksocket_t sock, struct sockaddr *socket_address,
+    unsigned long socklen)
+{
+	return (connect(sock, socket_address, socklen));
+}
+
+void
+ksock_close(ksocket_t sock)
+{
+	close(sock);
+}
+
+int
+ksock_shutdown(ksocket_t sock, int how)
+{
+	return (shutdown(sock, how));
+}
+
+size_t
+ksock_send(ksocket_t sock, struct msghdr *msg, kvec_t *iov,
+    int iovcnt, int total_size)
+{
+	return (writev(sock, iov, iovcnt));
+}
+
+size_t
+ksock_receive(ksocket_t sock, struct msghdr *msg, kvec_t *iov,
+    int iovcnt, int total_size, int flags)
+{
+	return (readv(sock, iov, iovcnt));
+}
+
+#endif /* _KERNEL */

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -5357,7 +5357,6 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 	metaslab_t *msp;
 	spa_t *spa = vd->vdev_spa;
 
-#ifdef _KERNEL
 	if (vd->vdev_ops == &vdev_object_store_ops) {
 		/*
 		 * XXX might be better to put it in ms_freeing and then send up
@@ -5367,7 +5366,6 @@ metaslab_free_concrete(vdev_t *vd, uint64_t offset, uint64_t asize,
 		object_store_free_block(vd, offset, asize);
 		return;
 	}
-#endif
 
 	ASSERT(vdev_is_concrete(vd));
 	ASSERT3U(spa_config_held(spa, SCL_ALL, RW_READER), !=, 0);
@@ -6049,10 +6047,8 @@ metaslab_check_free_impl(vdev_t *vd, uint64_t offset, uint64_t size)
 	if ((zfs_flags & ZFS_DEBUG_ZIO_FREE) == 0)
 		return;
 
-#ifdef _KERNEL
 	if (vd->vdev_ops == &vdev_object_store_ops)
 		return;
-#endif
 
 	if (vd->vdev_ops->vdev_op_remap != NULL) {
 		vd->vdev_ops->vdev_op_remap(vd, offset, size,

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3706,7 +3706,6 @@ copy_objstore_credentials(nvlist_t *src, nvlist_t *dest)
 			    ZPOOL_CONFIG_GUID) != guid) {
 				continue;
 			}
-
 			fnvlist_add_string(dchild[c2],
 			    ZPOOL_CONFIG_OBJSTORE_CREDENTIALS, creds);
 			break;
@@ -9235,11 +9234,9 @@ spa_sync(spa_t *spa, uint64_t txg)
 
 	VERIFY(spa_writeable(spa));
 
-#ifdef _KERNEL
 	if (!spa_normal_class(spa)->mc_ops->msop_block_based) {
 		object_store_begin_txg(spa, txg);
 	}
-#endif
 
 	/*
 	 * Wait for i/os issued in open context that need to complete

--- a/module/zfs/vdev.c
+++ b/module/zfs/vdev.c
@@ -226,9 +226,7 @@ static vdev_ops_t *vdev_ops_table[] = {
 	&vdev_missing_ops,
 	&vdev_hole_ops,
 	&vdev_indirect_ops,
-#ifdef _KERNEL
 	&vdev_object_store_ops,
-#endif
 	NULL
 };
 
@@ -5177,11 +5175,9 @@ vdev_is_concrete(vdev_t *vd)
 boolean_t
 vdev_is_object_based(vdev_t *vd)
 {
-#ifdef _KERNEL
 	vdev_ops_t *ops = vd->vdev_ops;
 	if (ops == &vdev_object_store_ops)
 		return (B_TRUE);
-#endif
 	return (B_FALSE);
 }
 

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -778,9 +778,7 @@ vdev_label_read_config(vdev_t *vd, uint64_t txg)
 		return (vdev_draid_read_config_spare(vd));
 
 	if (vdev_is_object_based(vd)) {
-#ifdef _KERNEL
 		return (vdev_object_store_get_config(vd));
-#endif
 	}
 
 	for (int l = 0; l < VDEV_LABELS; l++) {
@@ -1514,10 +1512,8 @@ vdev_uberblock_load_impl(zio_t *zio, vdev_t *vd, int flags,
 		vdev_uberblock_load_impl(zio, vd->vdev_child[c], flags, cbp);
 
 	if (vdev_is_object_based(vd)) {
-#ifdef _KERNEL
 		uberblock_t *ub = vdev_object_store_get_uberblock(vd);
 		vdev_uberblock_load_done_impl(zio->io_spa, vd, ub, zio);
-#endif
 	} else if (vd->vdev_ops->vdev_op_leaf && vdev_readable(vd) &&
 	    vd->vdev_ops != &vdev_draid_spare_ops) {
 		for (int l = 0; l < VDEV_LABELS; l++) {
@@ -1581,11 +1577,10 @@ vdev_uberblock_load(vdev_t *rvd, uberblock_t *ub, nvlist_t **config)
 			vdev_dbgmsg(cb.ubl_vd, "failed to read label config");
 		}
 	} else if (cb.ubl_vd != NULL && vdev_is_object_based(cb.ubl_vd)) {
-#ifdef _KERNEL
 		*config = vdev_object_store_get_config(cb.ubl_vd);
-#endif
 		if (*config == NULL) {
-			vdev_dbgmsg(cb.ubl_vd, "failed to read objstore label config");
+			vdev_dbgmsg(cb.ubl_vd, "failed to read objstore label "
+			"config");
 		}
 	}
 	spa_config_exit(spa, SCL_ALL, FTAG);
@@ -1939,7 +1934,6 @@ retry:
 
 	ASSERT3U(txg, <=, spa->spa_final_txg);
 
-#ifdef _KERNEL
 	if (spa->spa_root_vdev->vdev_child[0]->vdev_ops ==
 	    &vdev_object_store_ops) {
 		nvlist_t *label = spa_config_generate(spa,
@@ -1947,7 +1941,6 @@ retry:
 		object_store_end_txg(spa, label, txg);
 		return (0);
 	}
-#endif
 
 	/*
 	 * Flush the write cache of every disk that's been written to

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -1367,9 +1367,7 @@ zio_read_phys(zio_t *pio, vdev_t *vd, uint64_t offset, uint64_t size,
 	ASSERT(!labels || offset + size <= VDEV_LABEL_START_SIZE ||
 	    offset >= vd->vdev_psize - VDEV_LABEL_END_SIZE);
 	ASSERT3U(offset + size, <=, vd->vdev_psize);
-#ifdef _KERNEL
 	ASSERT3P(vd->vdev_ops, !=, &vdev_object_store_ops);
-#endif
 
 	zio = zio_create(pio, vd->vdev_spa, 0, NULL, data, size, size, done,
 	    private, ZIO_TYPE_READ, priority, flags | ZIO_FLAG_PHYSICAL, vd,
@@ -1391,9 +1389,7 @@ zio_write_phys(zio_t *pio, vdev_t *vd, uint64_t offset, uint64_t size,
 	ASSERT(!labels || offset + size <= VDEV_LABEL_START_SIZE ||
 	    offset >= vd->vdev_psize - VDEV_LABEL_END_SIZE);
 	ASSERT3U(offset + size, <=, vd->vdev_psize);
-#ifdef _KERNEL
 	ASSERT3P(vd->vdev_ops, !=, &vdev_object_store_ops);
-#endif
 
 	zio = zio_create(pio, vd->vdev_spa, 0, NULL, data, size, size, done,
 	    private, ZIO_TYPE_WRITE, priority, flags | ZIO_FLAG_PHYSICAL, vd,


### PR DESCRIPTION
With these changes, ztest runs on object-store based zpools. I was able to get it to run for 8 hours after which it crashed due to a problem that looks unrelated to this change.
```
root@mj-dose:/export/home/delphix/zfs/cmd/ztest# date; ./ztest -O https://s3-us-west-2.amazonaws.com -A us-west-2 -b cloudburst-data-2 -z file:///etc/zfs/zpool_credentials -T 30 -VV; date
Tue May 11 07:35:34 UTC 2021
7 datasets, 23 threads, object-store https://s3-us-west-2.amazonaws.com, 30 seconds...

Skipping executing zdb.
error == 0 (0x1c == 0)
ASSERT at ../../module/zfs/zio.c:3509:zio_object_allocate_and_issue()/export/home/delphix/zfs/cmd/ztest/.libs/ztest(+0x9eb3)[0x55ed58a48eb3]
<snip>
child died with signal 6
Tue May 11 15:40:57 UTC 2021
root@mj-dose:/export/home/delphix/zfs/cmd/ztest# 
```

```
#2  0x00007f2c0f9b6080 in libspl_assertf (file=file@entry=0x7f2c0febb34b "../../module/zfs/zio.c", func=func@entry=0x7f2c0febdd40 <__FUNCTION__.20224> "zio_object_allocate_and_issue", line=line@entry=3509, 
    format=format@entry=0x7f2c0fe7274a "%s == 0 (0x%llx == 0)") at assert.c:45
#3  0x00007f2c0fdc4aa0 in zio_object_allocate_and_issue (zio=0x7f2bd4151970) at ../../module/zfs/zio.c:3509
#4  0x00007f2c0fdbbe56 in __zio_execute (zio=0x7f2bd4151970) at ../../module/zfs/zio.c:2201
#5  zio_execute (zio=<optimized out>) at ../../module/zfs/zio.c:2114
#6  0x00007f2c0fc1e2c8 in taskq_thread (arg=0x5583fee97490) at taskq.c:237
#7  0x00007f2c0f1d56db in start_thread (arg=0x7f2c0c67e700) at pthread_create.c:463
#8  0x00007f2c0eefe71f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

These changes also permit zdb to be run on an active zpool. Well, it works to a point...
```
root@mj-dose:/export/home/delphix/zfs/cmd/ztest# zdb domain0/fs1@s1
Dataset domain0/fs1@s1 [ZPL], ID 73, cr_txg 47, 12K, 6 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    6   128K    16K  6.50K     512    32K    9.38  DMU dnode
        -1    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -2    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -3    1   128K    512      0     512    512  100.00  ZFS user/group/project used
         1    1   128K    512    512     512    512  100.00  ZFS master node
        32    1   128K    512      0     512    512  100.00  SA master node
        33    1   128K    512      0     512    512  100.00  ZFS delete queue
        34    1   128K    512      0     512    512  100.00  ZFS directory
        35    1   128K  1.50K    512     512  1.50K  100.00  SA attr registration
        36    1   128K    16K     4K     512    32K  100.00  SA attr layouts

    Dnode slots:
        Total used:             6
        Max used:              36
        Percent empty:  83.333333


ZFS_DBGMSG(zdb) START:
<snip>
ZFS_DBGMSG(zdb) END
root@mj-dose:/export/home/delphix/zfs/cmd/ztest# echo $?
0
root@mj-dose:/export/home/delphix/zfs/cmd/ztest#
root@mj-dose:/export/home/delphix/zfs/cmd/zfs_object_agent# zdb domain0

Cached configuration:
        version: 5000
        name: 'domain0'
        state: 0
        txg: 4
        pool_guid: 9654821730015360576
        errata: 0
        hostname: 'mj-dose.dcol2'
        com.delphix:has_per_vdev_zaps
        vdev_children: 1
        vdev_tree:
            type: 'root'
            id: 0
            guid: 9654821730015360576
            create_txg: 4
            children[0]:
                type: 'object_store'
                id: 0
                guid: 17085366176973410208
                path: 'cloudburst-data-2'
                object-credentials-location: 'file:///etc/zfs/zpool_credentials'
                object-endpoint: 'https://s3-us-west-2.amazonaws.com'
                object-region: 'us-west-2'
                metaslab_array: 65
                metaslab_shift: 59
                ashift: 9
                asize: 1152921504606584832
                is_log: 0
                create_txg: 4
                com.delphix:vdev_zap_leaf: 129
                com.delphix:vdev_zap_top: 130
        features_for_read:
            com.delphix:hole_birth
            com.delphix:embedded_data

MOS Configuration:
        version: 5000
        name: 'domain0'
        state: 0
        txg: 4
        pool_guid: 9654821730015360576
        errata: 0
        hostname: 'mj-dose.dcol2'
        com.delphix:has_per_vdev_zaps
        vdev_children: 1
        vdev_tree:
            type: 'root'
            id: 0
            guid: 9654821730015360576
            create_txg: 4
            children[0]:
                type: 'object_store'
                id: 0
                guid: 17085366176973410208
                path: 'cloudburst-data-2'
                object-credentials-location: 'file:///etc/zfs/zpool_credentials'
                object-endpoint: 'https://s3-us-west-2.amazonaws.com'
                object-region: 'us-west-2'
                metaslab_array: 65
                metaslab_shift: 59
                ashift: 9
                asize: 1152921504606584832
                is_log: 0
                create_txg: 4
                com.delphix:vdev_zap_leaf: 129
                com.delphix:vdev_zap_top: 130
        features_for_read:
            com.delphix:hole_birth
            com.delphix:embedded_data

Uberblock:
        magic = 0000000000bab10c
        version = 5000
        txg = 159
        guid_sum = 8293443833279219168
        timestamp = 1620718279 UTC = Tue May 11 07:31:19 2021
        mmp_magic = 00000000a11cea11
        mmp_delay = 0
        mmp_valid = 0
        checkpoint_txg = 0

All DDTs are empty

Metaslabs:
        vdev          0
        metaslabs     1   offset                spacemap          free
        ---------------   -------------------   ---------------   ------------
        metaslab      0   offset            0   spacemap      0   free     512P

        vdev          0         metaslabs    1          fragmentation  0%
        pool domain0    fragmentation     0%
Dataset mos [META], ID 0, cr_txg 4, 25.5K, 47 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    2   128K    16K     5K     512    80K   29.38  DMU dnode
         1    1   128K    16K  4.50K     512    32K  100.00  object directory
        32    1   128K    512      0     512    512    0.00  DSL directory
        33    1   128K    512      0     512    512  100.00  DSL props
        34    1   128K    512      0     512    512  100.00  DSL directory child map
        35    1   128K    512      0     512    512    0.00  DSL directory
        36    1   128K    512      0     512    512  100.00  DSL props
        37    1   128K    512      0     512    512  100.00  DSL directory child map
        38    1   128K    512      0     512    512    0.00  DSL directory
        39    1   128K    512      0     512    512  100.00  DSL props
        40    1   128K    512      0     512    512  100.00  DSL directory child map
        41    1   128K   128K      0     512   128K    0.00  bpobj
        42    1   128K    512      0     512    512    0.00  DSL directory
        43    1   128K    512      0     512    512  100.00  DSL props
        44    1   128K    512      0     512    512  100.00  DSL directory child map
        45    1   128K    512      0     512    512    0.00  DSL dataset
        46    1   128K    512      0     512    512  100.00  DSL dataset snap map
        47    1   128K    512      0     512    512  100.00  DSL deadlist map
        48    1   128K    512      0     512    512    0.00  DSL dataset
        49    1   128K    512      0     512    512  100.00  DSL deadlist map
        50    1   128K   128K      0     512   128K    0.00  bpobj
        51    1   128K  1.50K    512     512  1.50K  100.00  zap
        52    1   128K  1.50K    512     512  1.50K  100.00  zap
        53    1   128K    16K     6K     512    32K  100.00  zap
        54    1   128K    512      0     512    512  100.00  zap
        55    1   128K    512      0     512    512  100.00  DSL dataset snap map
        56    1   128K    512      0     512    512  100.00  DSL deadlist map
        57    1   128K   128K      0     512   128K    0.00  bpobj
        51    1   128K  1.50K    512     512  1.50K  100.00  zap
        52    1   128K  1.50K    512     512  1.50K  100.00  zap
        53    1   128K    16K     6K     512    32K  100.00  zap
        54    1   128K    512      0     512    512  100.00  zap
        55    1   128K    512      0     512    512  100.00  DSL dataset snap map
        56    1   128K    512      0     512    512  100.00  DSL deadlist map
        57    1   128K   128K      0     512   128K    0.00  bpobj
        58    1   128K    512      0     512    512  100.00  DSL dataset next clones
        59    1   128K    512      0     512    512  100.00  DSL dir clones
        60    1   128K   128K  2.50K     512   128K  100.00  SPA history
        61    1   128K    16K     1K     512    16K  100.00  packed nvlist
        62    1   128K    16K      0     512    16K  100.00  bpobj (Z=uncompressed)
        63    1   128K    16K     4K     512    32K  100.00  Pool properties
        64    1   128K     2K     1K     512     2K  100.00  zap
        65    1   128K    512      0     512    512    0.00  object array
        66    1   128K    512      0     512    512    0.00  DSL directory
        67    1   128K    512      0     512    512  100.00  DSL props
        68    1   128K    512      0     512    512  100.00  DSL directory child map
        69    1   128K    512      0     512    512  100.00  zap
        70    1   128K    512      0     512    512  100.00  DSL dataset snap map
        71    1   128K    512      0     512    512  100.00  DSL deadlist map
        72    1   128K   128K      0     512   128K    0.00  bpobj
        73    1   128K    512      0     512    512  100.00  zap
        74    1   128K    512      0     512    512  100.00  DSL deadlist map
       128    1   128K    512      0     512    512  100.00  zap
       129    1   128K    512      0     512    512  100.00  zap
       130    1   128K    512      0     512    512  100.00  zap

    Dnode slots:
        Total used:            47
        Max used:             130
        Percent empty:  63.846154

Dataset domain0/fs1@s1 [ZPL], ID 73, cr_txg 47, 12K, 6 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    6   128K    16K  6.50K     512    32K    9.38  DMU dnode
        -1    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -2    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -3    1   128K    512      0     512    512  100.00  ZFS user/group/project used
         1    1   128K    512    512     512    512  100.00  ZFS master node
        32    1   128K    512      0     512    512  100.00  SA master node
        33    1   128K    512      0     512    512  100.00  ZFS delete queue
        34    1   128K    512      0     512    512  100.00  ZFS directory
        35    1   128K  1.50K    512     512  1.50K  100.00  SA attr registration
        36    1   128K    16K     4K     512    32K  100.00  SA attr layouts

    Dnode slots:
        Total used:             6
        Max used:              36
        Percent empty:  83.333333

Dataset domain0/fs1 [ZPL], ID 69, cr_txg 43, 12K, 6 objects 

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    6   128K    16K  6.50K     512    32K    9.38  DMU dnode
        -1    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -2    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -3    1   128K    512      0     512    512  100.00  ZFS user/group/project used
         1    1   128K    512    512     512    512  100.00  ZFS master node
        32    1   128K    512      0     512    512  100.00  SA master node
        33    1   128K    512      0     512    512  100.00  ZFS delete queue
        34    1   128K    512      0     512    512  100.00  ZFS directory
        35    1   128K  1.50K    512     512  1.50K  100.00  SA attr registration
        36    1   128K    16K     4K     512    32K  100.00  SA attr layouts

    Dnode slots:
        Total used:             6
        Max used:              36
        Percent empty:  83.333333

Dataset domain0 [ZPL], ID 54, cr_txg 1, 12K, 7 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    6   128K    16K  6.50K     512    32K   10.94  DMU dnode
        -1    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -2    1   128K    512      0     512    512  100.00  ZFS user/group/project used
        -3    1   128K    512      0     512    512  100.00  ZFS user/group/project used
         1    1   128K    512    512     512    512  100.00  ZFS master node
         2    1   128K    512      0     512    512  100.00  ZFS directory
        32    1   128K    512      0     512    512  100.00  SA master node
        33    1   128K    512      0     512    512  100.00  ZFS delete queue
        34    1   128K    512      0     512    512  100.00  ZFS directory
        35    1   128K  1.50K    512     512  1.50K  100.00  SA attr registration
        36    1   128K    16K     4K     512    32K  100.00  SA attr layouts

    Dnode slots:
        Total used:             7
        Max used:              36
        Percent empty:  80.555556

Verified large_blocks feature refcount of 0 is correct
Verified large_dnode feature refcount of 0 is correct
Verified sha512 feature refcount of 0 is correct
Verified skein feature refcount of 0 is correct
Verified edonr feature refcount of 0 is correct
Verified userobj_accounting feature refcount of 3 is correct
Verified encryption feature refcount of 0 is correct
Verified project_quota feature refcount of 3 is correct
Verified redaction_bookmarks feature refcount of 0 is correct
Verified redacted_datasets feature refcount of 0 is correct 
Verified bookmark_written feature refcount of 0 is correct  
Verified livelist feature refcount of 0 is correct
Verified zstd_compress feature refcount of 0 is correct
Verified device_removal feature refcount of 0 is correct
Verified indirect_refcount feature refcount of 0 is correct 

Traversing all blocks to verify checksums and verify nothing leaked ...

loading concrete vdev 0, metaslab 0 of 1 ...
zio_wait(zio_claim(NULL, zcb->zcb_spa, refcnt ? 0 : spa_min_claim_txg(zcb->zcb_spa), bp, NULL, NULL, ZIO_FLAG_CANFAIL)) == 0 (0x2 == 0x0)
ASSERT at zdb.c:5324:zdb_count_block()Aborted (core dumped) 
root@mj-dose:/export/home/delphix/zfs/cmd/zfs_object_agent# 
```
```
#1  0x00007f2130ce3921 in __GI_abort () at abort.c:79
#2  0x00007f21314de050 in libspl_assertf (file=0x55f6dbe4d22c "zdb.c", func=0x55f6dbe53920 <__FUNCTION__.23550> "zdb_count_block", line=5324, format=<optimized out>) at assert.c:45
#3  0x000055f6dbe40639 in zdb_count_block (zcb=0x7ffc39270700, zilog=<optimized out>, bp=0x55f6dcaa6000, type=DMU_OT_NUMTYPES) at zdb.c:5322
#4  0x000055f6dbe409a4 in count_block_cb (arg=0x7ffc39270700, bp=0x55f6dcaa6000, tx=<optimized out>) at zdb.c:6203
#5  0x00007f213176a365 in bpobj_iterate_blkptrs (bpi=bpi@entry=0x55f6dca9c9c0, func=func@entry=0x55f6dbe409d0 <bpobj_count_block_cb>, arg=arg@entry=0x7ffc39270700, start=start@entry=0, tx=tx@entry=0x0, free=free@entry=B_FALSE)
    at ../../module/zfs/bpobj.c:307
#6  0x00007f213176b4cf in bpobj_iterate_impl (initial_bpo=<optimized out>, func=0x55f6dbe409d0 <bpobj_count_block_cb>, arg=0x7ffc39270700, tx=0x0, free=B_FALSE, bpobj_size=0x0) at ../../module/zfs/bpobj.c:383
#7  0x000055f6dbe41084 in dump_block_stats (spa=0x55f6dc964ff0) at zdb.c:6339
#8  0x000055f6dbe49bce in dump_zpool (spa=0x55f6dc964ff0) at zdb.c:7680
#9  0x000055f6dbe361c5 in main (argc=<optimized out>, argv=<optimized out>) at zdb.c:8750
```