### PR TITLE
rusoto & more

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -674,7 +674,6 @@ dependencies = [
  "futures",
  "futures-core",
  "lazy_static",
- "log",
  "lru",
  "more-asserts",
  "nvpair",

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -676,6 +676,8 @@ dependencies = [
  "lru",
  "nvpair",
  "rand",
+ "rusoto_core",
+ "rusoto_s3",
  "rust-s3",
  "serde",
  "stream-reduce",

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -670,6 +670,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "bincode",
+ "bytes",
  "futures",
  "futures-core",
  "lazy_static",

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru",
+ "more-asserts",
  "nvpair",
  "rand",
  "rusoto_core",
@@ -779,6 +780,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "native-tls"

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -92,6 +92,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,9 +166,16 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "serde",
+ "time 0.1.43",
  "winapi",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402da840495de3f976eaefc3485b7f5eb5b0bf9761f9a47be27fe975b3b8c2ec"
 
 [[package]]
 name = "core-foundation"
@@ -187,6 +200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -228,6 +250,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +269,23 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dlv-list"
@@ -1071,6 +1120,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aff20978970d47630f08de5f0d04799497818d16cafee5aec90c4b4d0806cf"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "lazy_static",
+ "log",
+ "rusoto_credential",
+ "rusoto_signature",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91e4c25ea8bfa6247684ff635299015845113baaa93ba8169b9e565701b58e"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "rusoto_s3"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc3f56f14ccf91f880b9a9c2d0556d8523e8c155041c54db155b384a1dd1119"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5486e6b1673ab3e0ba1ded284fb444845fe1b7f41d13989a54dd60f62a7b2baa"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "hyper",
+ "log",
+ "md5",
+ "percent-encoding",
+ "pin-project-lite",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2",
+ "time 0.2.26",
+ "tokio",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1240,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "url",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1156,6 +1295,21 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1213,6 +1367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sha2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1384,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1255,6 +1421,64 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stream-reduce"
@@ -1325,6 +1549,44 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
@@ -1632,6 +1894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+
+[[package]]
 name = "zfs_object_agent"
 version = "0.1.0"
 dependencies = [
@@ -1647,6 +1915,8 @@ dependencies = [
  "libzoa",
  "nvpair",
  "rand",
+ "rusoto_core",
+ "rusoto_s3",
  "rust-s3",
  "tokio",
 ]

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "futures",
  "futures-core",
  "lazy_static",
+ "log",
  "lru",
  "nvpair",
  "rand",

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "1.0"
 futures = "0.3.13"
 futures-core = "0.3.13"
 lazy_static = "1.4.0"
+log = "0.4.14"
 lru = "0.6.5"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -25,6 +25,7 @@ futures-core = "0.3.13"
 lazy_static = "1.4.0"
 log = "0.4.14"
 lru = "0.6.5"
+more-asserts = "0.2.1"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rusoto_core = "0.46.0"

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -23,7 +23,6 @@ bytes = "1.0"
 futures = "0.3.13"
 futures-core = "0.3.13"
 lazy_static = "1.4.0"
-log = "0.4.14"
 lru = "0.6.5"
 more-asserts = "0.2.1"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -25,6 +25,8 @@ lazy_static = "1.4.0"
 lru = "0.6.5"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
+rusoto_core = "0.46.0"
+rusoto_s3 = "0.46.0"
 rust-s3 = "0.27.0-rc1"
 serde = { version = "1.0.125", features = ["derive"] }
 stream-reduce = "0.1.0"

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -19,6 +19,7 @@ incremental = true
 anyhow = "1.0"
 async-stream = "0.3.0"
 bincode = "1.3.2"
+bytes = "1.0"
 futures = "0.3.13"
 futures-core = "0.3.13"
 lazy_static = "1.4.0"

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -11,5 +11,7 @@ futures = "0.3.13"
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rust-s3 = "0.27.0-rc1"
+rusoto_s3 = "0.46.0"
+rusoto_core = "0.46.0"
 tokio = { version = "1.4", features = ["full"] }
 libzoa = { path = "../" }

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.13"
+libzoa = { path = "../" }
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
-rust-s3 = "0.27.0-rc1"
-rusoto_s3 = "0.46.0"
 rusoto_core = "0.46.0"
+rusoto_s3 = "0.46.0"
+rust-s3 = "0.27.0-rc1"
 tokio = { version = "1.4", features = ["full"] }
-libzoa = { path = "../" }

--- a/cmd/zfs_object_agent/client/src/main.rs
+++ b/cmd/zfs_object_agent/client/src/main.rs
@@ -51,7 +51,11 @@ async fn do_s3(bucket: &Bucket) -> Result<(), Box<dyn Error>> {
 }
 
 async fn do_s3_rusoto() -> Result<(), Box<dyn Error>> {
+    //let http_client = HttpClient::new()?;
+    //let creds = StaticProvider::new("XXX".to_string(), "XXX".to_string(), None, None);
+    //let client = S3Client::new_with(http_client, creds, rusoto_core::Region::UsWest2);
     let client = S3Client::new(rusoto_core::Region::UsWest2);
+
     let key = "mahrens/test.file2";
 
     println!("getting {}", key);

--- a/cmd/zfs_object_agent/client/src/main.rs
+++ b/cmd/zfs_object_agent/client/src/main.rs
@@ -51,9 +51,6 @@ async fn do_s3(bucket: &Bucket) -> Result<(), Box<dyn Error>> {
 }
 
 async fn do_s3_rusoto() -> Result<(), Box<dyn Error>> {
-    //let http_client = HttpClient::new()?;
-    //let creds = StaticProvider::new("XXX".to_string(), "XXX".to_string(), None, None);
-    //let client = S3Client::new_with(http_client, creds, rusoto_core::Region::UsWest2);
     let client = S3Client::new(rusoto_core::Region::UsWest2);
 
     let key = "mahrens/test.file2";
@@ -83,16 +80,6 @@ async fn do_s3_rusoto() -> Result<(), Box<dyn Error>> {
         ..Default::default()
     };
     client.put_object(req).await?;
-
-    /*
-    let results = bucket.list("mahrens".to_string(), None).await?;
-    for list_results in results {
-        assert_eq!(code, 200);
-        for res in list_results.contents {
-            println!("found object {}", res.key);
-        }
-    }
-    */
 
     return std::result::Result::Ok(());
 }

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -228,14 +228,15 @@ impl ObjectAccess {
         }
     }
 
-pub async fn list_objects(
-    bucket: &Bucket,
-    prefix: &str,
-    delimiter: Option<String>,
-) -> Vec<s3::serde_types::ListBucketResult> {
-    let full_prefix = prefixed(prefix);
-    bucket.list(full_prefix, delimiter).await.unwrap()
-}
+    pub async fn list_objects(
+        &self,
+        prefix: &str,
+        delimiter: Option<String>,
+    ) -> Vec<s3::serde_types::ListBucketResult> {
+        let full_prefix = prefixed(prefix);
+        self.bucket.list(full_prefix, delimiter).await.unwrap()
+    }
+
     async fn put_object_impl(&self, key: &str, data: &[u8]) {
         let prefixed_key = &prefixed(key);
         retry(
@@ -337,17 +338,18 @@ pub async fn list_objects(
         let prefixed_key = prefixed(key);
         println!("looking for {}", prefixed_key);
         let begin = Instant::now();
-    match bucket.list(prefixed_key, None).await {
-        Ok(results) => {
-            assert!(results.len() == 1);
-            let list = &results[0];
-            println!("list completed in {}ms", begin.elapsed().as_millis());
-            // Note need to check if this exact name is in the results. If we are looking
-            // for "x/y" and there is "x/y" and "x/yz", both will be returned.
-            list.contents.iter().find(|o| o.key == key).is_some()
-        }
-        Err(_) => {
-            return false;
+        match self.bucket.list(prefixed_key, None).await {
+            Ok(results) => {
+                assert!(results.len() == 1);
+                let list = &results[0];
+                println!("list completed in {}ms", begin.elapsed().as_millis());
+                // Note need to check if this exact name is in the results. If we are looking
+                // for "x/y" and there is "x/y" and "x/yz", both will be returned.
+                list.contents.iter().find(|o| o.key == key).is_some()
+            }
+            Err(_) => {
+                return false;
+            }
         }
     }
 }

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -112,7 +112,7 @@ impl ObjectAccess {
 
     async fn get_object_impl(&self, key: &str) -> Vec<u8> {
         let msg = format!("get {}", prefixed(key));
-        let x = retry(&msg, || async {
+        let output = retry(&msg, || async {
             let req = GetObjectRequest {
                 bucket: self.bucket_str.clone(),
                 key: prefixed(key),
@@ -122,21 +122,22 @@ impl ObjectAccess {
         })
         .await;
         let begin = Instant::now();
-        let mut s = Vec::new();
-        x.body
+        let mut v = Vec::new();
+        output
+            .body
             .unwrap()
             .into_async_read()
-            .read_to_end(&mut s)
+            .read_to_end(&mut v)
             .await
             .unwrap();
         println!(
             "{}: got {} bytes of data in additional {}ms",
             msg,
-            s.len(),
+            v.len(),
             begin.elapsed().as_millis()
         );
 
-        s
+        v
     }
 
     pub async fn get_object(&self, key: &str) -> Arc<Vec<u8>> {

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -3,6 +3,7 @@ use core::time::Duration;
 use futures::Future;
 use lazy_static::lazy_static;
 use lru::LruCache;
+use rand::prelude::*;
 use s3::bucket::Bucket;
 use std::collections::HashMap;
 use std::env;
@@ -38,7 +39,7 @@ where
 {
     println!("{}: begin", msg);
     let begin = Instant::now();
-    let mut delay = Duration::from_millis(100);
+    let delay = Duration::from_secs_f64(thread_rng().gen_range(0.001..0.2));
     let data = loop {
         match f().await {
             Err(e) => {
@@ -63,7 +64,7 @@ where
             }
         }
         tokio::time::sleep(delay).await;
-        delay *= 2;
+        delay.mul_f64(thread_rng().gen_range(1.5..2.5));
     };
     println!(
         "{}: returned {} bytes in {}ms",

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -49,7 +49,7 @@ where
 {
     println!("{}: begin", msg);
     let begin = Instant::now();
-    let delay = Duration::from_secs_f64(thread_rng().gen_range(0.001..0.2));
+    let mut delay = Duration::from_secs_f64(thread_rng().gen_range(0.001..0.2));
     let data = loop {
         match f().await {
             Err(e) => {
@@ -74,7 +74,7 @@ where
             }
         }
         tokio::time::sleep(delay).await;
-        delay.mul_f64(thread_rng().gen_range(1.5..2.5));
+        delay = delay.mul_f64(thread_rng().gen_range(1.5..2.5));
     };
     println!(
         "{}: returned {} bytes in {}ms",
@@ -92,7 +92,7 @@ where
 {
     println!("{}: begin", msg);
     let begin = Instant::now();
-    let delay = Duration::from_secs_f64(thread_rng().gen_range(0.001..0.2));
+    let mut delay = Duration::from_secs_f64(thread_rng().gen_range(0.001..0.2));
     let data = loop {
         match f().await {
             Err(e) => {
@@ -104,7 +104,7 @@ where
             }
         }
         tokio::time::sleep(delay).await;
-        delay.mul_f64(thread_rng().gen_range(1.5..2.5));
+        delay = delay.mul_f64(thread_rng().gen_range(1.5..2.5));
     };
     println!(
         "{}: returned success in {}ms",

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -279,7 +279,7 @@ impl ObjectAccess {
         let begin = Instant::now();
         match self.bucket.list(prefixed_key, None).await {
             Ok(results) => {
-                assert!(results.len() == 1);
+                assert_eq!(results.len(), 1);
                 let list = &results[0];
                 println!("list completed in {}ms", begin.elapsed().as_millis());
                 // Note need to check if this exact name is in the results. If we are looking

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -60,7 +60,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLogChunk<T> {
 
     async fn put(&self, object_access: &ObjectAccess, name: &str) {
         let begin = Instant::now();
-        let buf = &bincode::serialize(&self).unwrap();
+        let buf = bincode::serialize(&self).unwrap();
         println!(
             "serialized {} log entries in {}ms",
             self.entries.len(),

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -70,7 +70,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLogChunk<T> {
     }
 }
 
-#[derive(Debug)]
+//#[derive(Debug)]
 pub struct ObjectBasedLog<T: ObjectBasedLogEntry> {
     pool: Arc<PoolSharedState>,
     name: String,

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -162,8 +162,8 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         assert!(self.recovered);
         // XXX assert that txg is the same as the txg for the other pending entries?
         self.pending_entries.push(value);
-        // XXX should be based on chunk size (bytes)
-        if self.pending_entries.len() > 1000 {
+        // XXX should be based on chunk size (bytes)?  Or maybe should just be unlimited.
+        if self.pending_entries.len() > 100_000 {
             self.initiate_flush(txg);
         }
     }

--- a/cmd/zfs_object_agent/src/object_block_map.rs
+++ b/cmd/zfs_object_agent/src/object_block_map.rs
@@ -1,4 +1,5 @@
 use crate::base_types::*;
+use more_asserts::*;
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::ops::Bound::*;
@@ -37,8 +38,8 @@ impl ObjectBlockMap {
         let mut prev_ent_opt: Option<ObjectBlockMapEntry> = None;
         for ent in self.map.iter() {
             if let Some(prev_ent) = prev_ent_opt {
-                assert!(ent.obj > prev_ent.obj);
-                assert!(ent.block > prev_ent.block);
+                assert_gt!(ent.obj, prev_ent.obj);
+                assert_gt!(ent.block, prev_ent.block);
             }
             prev_ent_opt = Some(*ent);
         }
@@ -48,11 +49,11 @@ impl ObjectBlockMap {
         // verify that this block is between the existing entries blocks
         let prev_ent_opt = self.map.range((Unbounded, Excluded(obj))).next_back();
         if let Some(prev_ent) = prev_ent_opt {
-            assert!(prev_ent.block < block);
+            assert_lt!(prev_ent.block, block);
         }
         let next_ent_opt = self.map.range((Excluded(obj), Unbounded)).next();
         if let Some(next_ent) = next_ent_opt {
-            assert!(next_ent.block > block);
+            assert_gt!(next_ent.block, block);
         }
         // verify that this object is not yet in the map
         assert!(!self.map.contains(&obj));

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -400,6 +400,7 @@ impl Pool {
         );
 
         // load free map just to verify
+        /*
         let begin = Instant::now();
         let mut frees: HashSet<BlockID> = HashSet::new();
         syncing_state
@@ -419,6 +420,7 @@ impl Pool {
             frees.len(),
             begin.elapsed().as_millis()
         );
+        */
         //println!("{:#?}", frees);
         let next_block = Self::next_block_locked(&syncing_state);
         drop(syncing_state);

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -292,9 +292,9 @@ impl PoolSyncingState {
 }
 
 impl Pool {
-    pub async fn get_config(bucket: &Bucket, guid: PoolGUID) -> NvList {
-        let pool_phys = PoolPhys::get(bucket, guid).await;
-        let ubphys = UberblockPhys::get(bucket, pool_phys.guid, pool_phys.last_txg).await;
+    pub async fn get_config(object_access: &ObjectAccess, guid: PoolGUID) -> NvList {
+        let pool_phys = PoolPhys::get(object_access, guid).await;
+        let ubphys = UberblockPhys::get(object_access, pool_phys.guid, pool_phys.last_txg).await;
         NvList::try_unpack(&ubphys.zfs_config).unwrap()
     }
 

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -228,6 +228,7 @@ impl Server {
                 }
             }
         }
+        println!("sending response: {:?}", nvl);
         Self::send_response(&self.output, nvl).await;
     }
 


### PR DESCRIPTION
- use rusoto for most S3 calls
- add ObjectAccess struct to encapsulate data needed for S3 calls (rusoto or rust-s3)
- add jitter to S3 retryer
- creds/endpoint strings procesing moved from Server to ObjectAccess
- delete multiple objects with one S3 call
- ObjectBasedLog track num_entries
- target DataObject size is now 1MB (before was 100 blocks)
- target ObjectBasedLog size is now 100,000 entries (before was 1000 entries)
- pending frees high/low-water changed to 10%/9%
- DataObject tracks min/max blockID and min/max txg
- simplified members tracking PendingObject
- improved object-consolidation logic; throttle put/get requests