### PR TITLE
improved flush command

### DIFF
--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -124,12 +124,8 @@ impl ObjectAccess {
         }
     }
 
-    pub fn release_client(mut self) -> S3Client {
-        let old = std::mem::replace(
-            &mut self.client,
-            rusoto_s3::S3Client::new(rusoto_core::Region::UsWest2),
-        );
-        old
+    pub fn release_client(self) -> S3Client {
+        self.client
     }
 
     async fn get_object_impl(&self, key: &str) -> Vec<u8> {


### PR DESCRIPTION
I think this should make the "flush writes" command work correctly with out-of-order write processing.