### PR TITLE
Use prefixes for data objects to increase parallelism

### DIFF
--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -186,7 +186,7 @@ impl UberblockPhys {
 
 impl DataObjectPhys {
     fn key(guid: PoolGUID, obj: ObjectID) -> String {
-        format!("zfs/{}/data/{}", guid, obj)
+        format!("zfs/{}/data/{}/{}", guid, obj.0 % 64, obj)
     }
 
     fn verify(&self) {


### PR DESCRIPTION
AWS's guidance on how exactly this works, and whether you need to do anything beyond just "having separate prefixes" to get improved performance, is *extremely* unclear. From what I can tell, the simple version of the design is that the prefix of an object (everything up to the last /) is used as a key in a hash table to determine what node(s) to go talk to.

Now, does this mean you could just have every object end with "/data" and then each is its own prefix, giving you the maximum theoretical requests per object? Maybe, but my guess is no. My guess is that if expanding a particular "directory" (thing between two /s) would make the hash table larger than a certain size, they don't use that as part of the partitioning scheme. Maybe that size is linked to the number of objects in the bucket, or the size of the bucket in bytes, or it's a constant, or it's a function or your AWS account number and the zodiac sign of the person who created the bucket. Or maybe there's a minimum number of objects required to make a partition, so they won't partition any prefix with less than N objects in it. Short of talking to someone who work at AWS, I don't know of a good way to find out how this actually works.

Given that we hopefully don't need to issue a thousand PUTs or GETs to a single object in a second, it also shouldn't matter.  Therefore I started with a safe middle ground of 64 folders in the hopes that we would get 64 partitions per pool, enabling hundreds of thousands of requests per second per pool.

See https://aws.amazon.com/premiumsupport/knowledge-center/s3-object-key-naming-pattern/
https://aws.amazon.com/about-aws/whats-new/2018/07/amazon-s3-announces-increased-request-rate-performance/
and https://aws.amazon.com/premiumsupport/knowledge-center/s3-prefix-nested-folders-difference/ for more information.