### PR TITLE
zdb support for object-store based zpools

### DIFF
--- a/lib/libzutil/os/linux/zutil_import_os.c
+++ b/lib/libzutil/os/linux/zutil_import_os.c
@@ -517,7 +517,7 @@ zpool_find_import_agent(libpc_handle_t *hdl, importargs_t *iarg,
 		if (nvlist_lookup_uint64(tree, ZPOOL_CONFIG_GUID, &guid) != 0) {
 			continue;
 		}
-		
+
 		slice = zutil_alloc(hdl, sizeof (rdsk_node_t));
 		if (asprintf(&slice->rn_name, "%s", fnvlist_lookup_string(tree,
 		    ZPOOL_CONFIG_PATH)) == -1) {


### PR DESCRIPTION
This change enables zdb to inspect an object-store based zpool that is exported/not in a cachefile.
I also enables ztest to run zdb.

Caveat: If there are multiple pools with the same name, zdb struggles as it does not yet know how to specify the pool ID. For example, when there are multiple "ztest" pools in the bucket, zdb fails.

```
root@mj-dose:/export/home/delphix/zfs/cmd/zdb# ./zdb -e -a https://s3-us-west-2.amazonaws.com -g us-west-2 -B cloudburst-data-2 -f file:///etc/zfs/zpool_credentials ztest | more

Configuration for import:
        vdev_children: 1
        version: 5000
        pool_guid: 9962155298875414703
        name: 'ztest'
        state: 0
        vdev_tree:
            type: 'root'
            id: 0
            guid: 9962155298875414703
            children[0]:
                type: 'object_store'
                id: 0
                guid: 17635164701915965417
                object-credentials-location: 'file:///etc/zfs/zpool_credentials'
                object-endpoint: 'https://s3-us-west-2.amazonaws.com'
                object-region: 'us-west-2'
                metaslab_array: 68
                metaslab_shift: 59
                ashift: 9
                asize: 1152921504606584832
                is_log: 0
                create_txg: 4
                objstore_credentials: 'AKIAUW6JOZCF4YQNTF4P:jSb8cNLeSntTszxb82cNrhhtvTjKPtNWKyrzNOO8
'
                path: 'cloudburst-data-2'
        load-policy:
            load-request-txg: 18446744073709551615
            load-rewind-policy: 2

MOS Configuration:
        version: 5000
        name: 'ztest'
        state: 0
        txg: 4
        pool_guid: 9962155298875414703
        errata: 0
        hostname: 'mj-dose.dcol2'
        com.delphix:has_per_vdev_zaps
        vdev_children: 1
        vdev_tree:
            type: 'root'
            id: 0
            guid: 9962155298875414703
            create_txg: 4
            children[0]:
                type: 'object_store'
                id: 0
                guid: 17635164701915965417
                path: 'cloudburst-data-2'
                object-credentials-location: 'file:///etc/zfs/zpool_credentials'
                objstore_credentials: 'AKIAUW6JOZCF4YQNTF4P:jSb8cNLeSntTszxb82cNrhhtvTjKPtNWKyrzNOO8
'
                object-endpoint: 'https://s3-us-west-2.amazonaws.com'
                object-region: 'us-west-2'
                metaslab_array: 68
                metaslab_shift: 59
                ashift: 9
                asize: 1152921504606584832
                is_log: 0
                create_txg: 4
                com.delphix:vdev_zap_leaf: 66  
                com.delphix:vdev_zap_top: 67   
        features_for_read:
            com.delphix:hole_birth
            com.delphix:embedded_data

Uberblock:
        magic = 0000000000bab10c
        version = 5000
        txg = 156
        guid_sum = 9150575927081828504
        timestamp = 1621554992 UTC = Thu May 20 23:56:32 2021
        mmp_magic = 00000000a11cea11
        mmp_delay = 0
        mmp_valid = 0
        checkpoint_txg = 0

All DDTs are empty

Metaslabs:
        vdev          0
        metaslabs     1   offset                spacemap          free
        ---------------   -------------------   ---------------   ------------
        metaslab      0   offset            0   spacemap      0   free     512P

        vdev          0         metaslabs    1          fragmentation  0%
        pool ztest      fragmentation     0%   
Dataset mos [META], ID 0, cr_txg 4, 22K, 45 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    1   128K    16K     3K     512    48K   46.88  DMU dnode
         1    1   128K    16K  4.50K     512    32K  100.00  object directory
         2    1   128K    512      0     512    512    0.00  DSL directory
         3    1   128K    512      0     512    512  100.00  DSL props
         4    1   128K    512      0     512    512  100.00  DSL directory child map
         5    1   128K    512    512     512    512  100.00  zap
         6    1   128K    512      0     512    512  100.00  DSL dataset snap map
         7    1   128K    512      0     512    512  100.00  DSL deadlist map
         8    1   128K   128K      0     512   128K    0.00  bpobj
        32    1   128K    512      0     512    512    0.00  DSL directory
        33    1   128K    512      0     512    512  100.00  DSL props
        34    1   128K    512      0     512    512  100.00  DSL directory child map
        35    1   128K    512      0     512    512    0.00  DSL directory
        36    1   128K    512      0     512    512  100.00  DSL props
        37    1   128K    512      0     512    512  100.00  DSL directory child map
        38    1   128K    512      0     512    512    0.00  DSL directory
        39    1   128K    512      0     512    512  100.00  DSL props
        40    1   128K    512      0     512    512  100.00  DSL directory child map
        41    1   128K   128K      0     512   128K    0.00  bpobj
        42    1   128K    512      0     512    512    0.00  DSL directory
        43    1   128K    512      0     512    512  100.00  DSL props
        44    1   128K    512      0     512    512  100.00  DSL directory child map
        45    1   128K    512      0     512    512    0.00  DSL dataset
        46    1   128K    512      0     512    512  100.00  DSL dataset snap map
        47    1   128K    512      0     512    512  100.00  DSL deadlist map
        48    1   128K    512      0     512    512    0.00  DSL dataset
        49    1   128K    512      0     512    512  100.00  DSL deadlist map
        50    1   128K   128K      0     512   128K    0.00  bpobj
        51    1   128K  1.50K    512     512  1.50K  100.00  zap
        52    1   128K  1.50K    512     512  1.50K  100.00  zap
        53    1   128K    16K     6K     512    32K  100.00  zap
        54    1   128K    512      0     512    512    0.00  DSL dataset
        55    1   128K    512      0     512    512  100.00  DSL dataset snap map
        56    1   128K    512      0     512    512  100.00  DSL deadlist map
        57    1   128K   128K      0     512   128K    0.00  bpobj
        58    1   128K    512      0     512    512  100.00  DSL dataset next clones
        59    1   128K    512      0     512    512  100.00  DSL dir clones
        60    1   128K   128K  4.50K     512   128K  100.00  SPA history
        61    1   128K    16K     1K     512    16K  100.00  packed nvlist
        62    1   128K    16K    512     512    16K  100.00  bpobj (Z=uncompressed)
        63    1   128K    512      0     512    512  100.00  Pool properties
        64    1   128K     2K     1K     512     2K  100.00  zap
        65    1   128K    512      0     512    512  100.00  zap
        66    1   128K    512      0     512    512  100.00  zap
        67    1   128K    512      0     512    512  100.00  zap
        68    1   128K    512      0     512    512    0.00  object array

    Dnode slots:
        Total used:            45
        Max used:              68
        Percent empty:  33.823529

Dataset ztest/ds_0 [OTHER], ID 5, cr_txg 15, 10K, 5 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    6   128K    16K     8K     512   416K    0.60  DMU dnode
         1    1   128K    512      0     512    512  100.00  other ZAP
       820    1    64K     1K      0     512     1K    0.00  other uint64[]
       821    1    64K   256K      0      2K   256K    0.00  other uint64[]
       825    3    16K     1M  1.50K   1.50K   881M    0.23  other uint64[]
       828    1    32K   512K      0     512   512K    0.00  other uint64[]

    Dnode slots:
        Total used:            10
        Max used:             828
        Percent empty:  98.792271

Dataset ztest [ZPL], ID 54, cr_txg 1, 512, 0 objects

    Object  lvl   iblk   dblk  dsize  dnsize  lsize   %full  type
         0    6   128K    16K      0     512    16K    0.00  DMU dnode

    Dnode slots:
        Total used:             0
        Max used:               0
        Percent empty:       -nan

Verified large_blocks feature refcount of 1 is correct
Verified large_dnode feature refcount of 1 is correct
Verified sha512 feature refcount of 0 is correct
Verified skein feature refcount of 0 is correct
Verified edonr feature refcount of 0 is correct
Verified userobj_accounting feature refcount of 0 is correct
Verified encryption feature refcount of 0 is correct
Verified project_quota feature refcount of 0 is correct
Verified redaction_bookmarks feature refcount of 0 is correct
Verified redacted_datasets feature refcount of 0 is correct
Verified bookmark_written feature refcount of 0 is correct
Verified livelist feature refcount of 0 is correct
Verified zstd_compress feature refcount of 1 is correct
Verified device_removal feature refcount of 0 is correct
Verified indirect_refcount feature refcount of 0 is correct

Skipping leak detection for object-store based zpool.


Traversing all blocks to verify checksums ...  


        bp count:                    56
        ganged count:                 0
        bp logical:             3301888      avg:  58962
        bp physical:              39936      avg:    713     compression:  82.68
        bp allocated:             39936      avg:    713     compression:  82.68
        bp deduped:                   0    ref>1:      0   deduplication:   1.00
        Normal class:                 0     used:  0.00%

        additional, non-pointer bps of type 0:         26

Blocks  LSIZE   PSIZE   ASIZE     avg    comp   %Total  Type
     -      -       -       -       -       -        -  unallocated
     2    32K   4.50K   4.50K   2.25K    7.11    11.54  object directory
     -      -       -       -       -       -        -  object array
     1    16K      1K      1K      1K   16.00     2.56  packed nvlist
     -      -       -       -       -       -        -  packed nvlist size
     1    16K     512     512     512   32.00     1.28  bpobj
     -      -       -       -       -       -        -  bpobj header
     -      -       -       -       -       -        -  SPA space map header
     -      -       -       -       -       -        -  SPA space map
     -      -       -       -       -       -        -  ZIL intent log
    10   720K     11K     11K   1.10K   65.45    28.21  DMU dnode
     3     7K   1.50K   1.50K     512    4.67     3.85  DMU objset
     -      -       -       -       -       -        -  DSL directory
     -      -       -       -       -       -        -  DSL directory child map
     -      -       -       -       -       -        -  DSL dataset snap map
     -      -       -       -       -       -        -  DSL props
     -      -       -       -       -       -        -  DSL dataset
     -      -       -       -       -       -        -  ZFS znode
     -      -       -       -       -       -        -  ZFS V0 ACL
     -      -       -       -       -       -        -  ZFS plain file
     -      -       -       -       -       -        -  ZFS directory
     -      -       -       -       -       -        -  ZFS master node
     -      -       -       -       -       -        -  ZFS delete queue
     -      -       -       -       -       -        -  zvol object
     -      -       -       -       -       -        -  zvol prop
     -      -       -       -       -       -        -  other uint8[]
     5  2.05M   1.50K   1.50K     307   1397.33   3.85  other uint64[]
     -      -       -       -       -       -        -  other ZAP
     -      -       -       -       -       -        -  persistent error log
     1   128K   4.50K   4.50K   4.50K   28.44    11.54  SPA history
     -      -       -       -       -       -        -  SPA history offsets
     -      -       -       -       -       -        -  Pool properties
     -      -       -       -       -       -        -  DSL permissions
     -      -       -       -       -       -        -  ZFS ACL
     -      -       -       -       -       -        -  ZFS SYSACL
     -      -       -       -       -       -        -  FUID table
     -      -       -       -       -       -        -  FUID table size
     -      -       -       -       -       -        -  DSL dataset next clones
     -      -       -       -       -       -        -  scan work queue
     -      -       -       -       -       -        -  ZFS user/group/project used
     -      -       -       -       -       -        -  ZFS user/group/project quota
     -      -       -       -       -       -        -  snapshot refcount tags
     -      -       -       -       -       -        -  DDT ZAP algorithm
     -      -       -       -       -       -        -  DDT statistics
     -      -       -       -       -       -        -  System attributes
     -      -       -       -       -       -        -  SA master node
     -      -       -       -       -       -        -  SA attr registration
     -      -       -       -       -       -        -  SA attr layouts
     -      -       -       -       -       -        -  scan translations
     -      -       -       -       -       -        -  deduplicated block
     -      -       -       -       -       -        -  DSL deadlist map
     -      -       -       -       -       -        -  DSL deadlist map hdr
     -      -       -       -       -       -        -  DSL dir clones
     -      -       -       -       -       -        -  bpobj subobj
     3   160K      6K      6K      2K   26.67    15.38  deferred free
     -      -       -       -       -       -        -  dedup ditto
     9    39K   8.50K   8.50K     967    4.59    21.79  other
    56  3.15M     39K     39K     713   82.68   100.00  Total

Block Size Histogram

  block   psize                lsize                asize
   size   Count   Size   Cum.  Count   Size   Cum.  Count   Size   Cum.
    512:     15  7.50K  7.50K      1    512    512     15  7.50K  7.50K
     1K:     10  10.5K    18K      3     4K  4.50K     10  10.5K    18K
     2K:      1  2.50K  20.5K      2     4K  8.50K      1  2.50K  20.5K
     4K:      4  18.5K    39K      1     4K  12.5K      4  18.5K    39K
     8K:      0      0    39K      0      0  12.5K      0      0    39K
    16K:      0      0    39K     16   256K   268K      0      0    39K
    32K:      0      0    39K      0      0   268K      0      0    39K
    64K:      0      0    39K      0      0   268K      0      0    39K
   128K:      0      0    39K      7   896K  1.14M      0      0    39K
   256K:      0      0    39K      0      0  1.14M      0      0    39K
   512K:      0      0    39K      0      0  1.14M      0      0    39K
     1M:      0      0    39K      0      0  1.14M      0      0    39K
     2M:      0      0    39K      0      0  1.14M      0      0    39K
     4M:      0      0    39K      0      0  1.14M      0      0    39K
     8M:      0      0    39K      0      0  1.14M      0      0    39K
    16M:      0      0    39K      0      0  1.14M      0      0    39K

                            capacity   operations   bandwidth  ---- errors ----
description                used avail  read write  read write  read write cksum
ztest                         0  512P    48     0 57.5K     0     0     0     0
  cloudburst-data-2           0  512P    48     0 57.5K     0     0     0     0

History:
2021-05-20.23:54:06 [txg:4] create pool version 5000; software version zfs-0.7.0-5008-gc211229ad; uts mj-dose.dcol2 5.4.0-73-dx2021051305-4c331f84b-generic #82~18.04.1 SMP Thu May 13 05:32:51 UTC 2021 x86_64
  history internal str: 'pool version 5000; software version zfs-0.7.0-5008-gc211229ad; uts mj-dose.dcol2 5.4.0-73-dx2021051305-4c331f84b-generic #82~18.04.1 SMP Thu May 13 05:32:51 UTC 2021 x86_64'
  internal_name: 'create'
<snip>

ZFS_DBGMSG(zdb) START:
spa.c:6090:spa_import(): spa_import: importing ztest
spa_misc.c:419:spa_load_note(): spa_load(ztest, config trusted): LOADING
vdev_object_store.c:674:vdev_object_store_init(): vdev_object_store_init, endpoint=https://s3-us-west-2.amazonaws.com region=us-west-2 cred=AKIAUW6JOZCF4YQNTF4P:jSb8cNLeSntTszxb82cNrhhtvTjKPtNWKyrzNOO8
<snip>
ZFS_DBGMSG(zdb) END
root@mj-dose:/export/home/delphix/zfs/cmd/zdb# 
```