### PR TITLE
Agent recovery

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "rusoto_s3",
  "serde",
  "serde_bytes",
+ "serde_json",
  "stream-reduce",
  "tokio",
  "tokio-stream",

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -32,6 +32,7 @@ rusoto_core = "0.46.0"
 rusoto_s3 = "0.46.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_bytes = "0.11"
+serde_json = "1.0.64"
 stream-reduce = "0.1.0"
 tokio = { version = "1.4", features = ["full"] }
 tokio-stream = "0.1.5"

--- a/cmd/zfs_object_agent/server/src/main.rs
+++ b/cmd/zfs_object_agent/server/src/main.rs
@@ -22,10 +22,12 @@ fn setup_logging(verbosity: u64, file_name: Option<&str>) {
     };
 
     let mut config = fern::Dispatch::new().format(|out, message, record| {
+        let target = record.target();
+        let stripped_target = target.strip_prefix("libzoa").unwrap_or(target);
         out.finish(format_args!(
             "[{}][{}][{}] {}",
-            chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.6f"),
-            record.target(),
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+            stripped_target,
             record.level(),
             message
         ))

--- a/cmd/zfs_object_agent/src/base_types.rs
+++ b/cmd/zfs_object_agent/src/base_types.rs
@@ -12,7 +12,7 @@ pub struct TXG(pub u64);
 impl OnDisk for TXG {}
 impl Display for TXG {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "{}", self.0)
+        write!(f, "{:020}", self.0)
     }
 }
 
@@ -21,7 +21,7 @@ pub struct PoolGUID(pub u64);
 impl OnDisk for PoolGUID {}
 impl Display for PoolGUID {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "{}", self.0)
+        write!(f, "{:020}", self.0)
     }
 }
 
@@ -30,7 +30,7 @@ pub struct ObjectID(pub u64);
 impl OnDisk for ObjectID {}
 impl Display for ObjectID {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "{}", self.0)
+        write!(f, "{:020}", self.0)
     }
 }
 impl ObjectID {

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -50,7 +50,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLogChunk<T> {
             .get_object(&Self::key(name, generation, chunk))
             .await;
         let begin = Instant::now();
-        let this: Self = bincode::deserialize(&buf).unwrap();
+        let this: Self = serde_json::from_slice(&buf).unwrap();
         debug!(
             "deserialized {} log entries in {}ms",
             this.entries.len(),
@@ -63,7 +63,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLogChunk<T> {
 
     async fn put(&self, object_access: &ObjectAccess, name: &str) {
         let begin = Instant::now();
-        let buf = bincode::serialize(&self).unwrap();
+        let buf = serde_json::to_vec(&self).unwrap();
         debug!(
             "serialized {} log entries in {}ms",
             self.entries.len(),

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -48,7 +48,8 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLogChunk<T> {
     async fn get(object_access: &ObjectAccess, name: &str, generation: u64, chunk: u64) -> Self {
         let buf = object_access
             .get_object(&Self::key(name, generation, chunk))
-            .await;
+            .await
+            .unwrap();
         let begin = Instant::now();
         let this: Self = serde_json::from_slice(&buf).unwrap();
         debug!(

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -140,7 +140,7 @@ impl PoolPhys {
 
     async fn get(object_access: &ObjectAccess, guid: PoolGUID) -> Self {
         let buf = object_access.get_object(&Self::key(guid)).await;
-        let this: Self = bincode::deserialize(&buf).unwrap();
+        let this: Self = serde_json::from_slice(&buf).unwrap();
         debug!("got {:#?}", this);
         assert_eq!(this.guid, guid);
         this
@@ -148,7 +148,7 @@ impl PoolPhys {
 
     async fn put(&self, object_access: &ObjectAccess) {
         debug!("putting {:#?}", self);
-        let buf = bincode::serialize(&self).unwrap();
+        let buf = serde_json::to_vec(&self).unwrap();
         object_access.put_object(&Self::key(self.guid), buf).await;
     }
 }
@@ -168,7 +168,7 @@ impl UberblockPhys {
 
     async fn get(object_access: &ObjectAccess, guid: PoolGUID, txg: TXG) -> Self {
         let buf = object_access.get_object(&Self::key(guid, txg)).await;
-        let this: Self = bincode::deserialize(&buf).unwrap();
+        let this: Self = serde_json::from_slice(&buf).unwrap();
         debug!("got {:#?}", this);
         assert_eq!(this.guid, guid);
         assert_eq!(this.txg, txg);
@@ -177,7 +177,7 @@ impl UberblockPhys {
 
     async fn put(&self, object_access: &ObjectAccess) {
         debug!("putting {:#?}", self);
-        let buf = bincode::serialize(&self).unwrap();
+        let buf = serde_json::to_vec(&self).unwrap();
         object_access
             .put_object(&Self::key(self.guid, self.txg), buf)
             .await;

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -278,7 +278,7 @@ impl Server {
                                     resp.insert(guid_str, pool_config.as_ref()).unwrap()
                                 }
                                 Err(e) => {
-                                    error!("skipping {:?}: {}", guid, e);
+                                    error!("skipping {:?}: {:?}", guid, e);
                                 }
                             }
                         }

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -271,10 +271,16 @@ impl Server {
                         debug!("prefix: {}", pfx);
                         let vector: Vec<&str> = pfx.rsplitn(3, '/').collect();
                         let guid_str: &str = vector[1];
-                        if let Ok(guid) = str::parse::<u64>(guid_str) {
-                            let pool_config =
-                                Pool::get_config(&object_access, PoolGUID(guid)).await;
-                            resp.insert(guid_str, pool_config.as_ref()).unwrap();
+                        if let Ok(guid64) = str::parse::<u64>(guid_str) {
+                            let guid = PoolGUID(guid64);
+                            match Pool::get_config(&object_access, guid).await {
+                                Ok(pool_config) => {
+                                    resp.insert(guid_str, pool_config.as_ref()).unwrap()
+                                }
+                                Err(e) => {
+                                    error!("skipping {:?}: {}", guid, e);
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- pad out numbers in keys to be 20 decimal digits
- change all but data objects to be JSON-encoded
- add "resume txg" and "resume complete" commands to get agent back into the same state as before we crashed.
- add just enough error handling for `zpool import` to not explode on old-format pools.  We can consider revising this once we have proper versioning of the on-disk format
- minor tweaks to log formatting

After running `zpool import` we see several error messages like these in the log.

example error message when object does not exist (due to padding `0`s):
```
[2021-05-24 04:10:39.248][::server][DEBUG] prefix: zfs/7889576177877413145/
[2021-05-24 04:10:39.248][::object_access][DEBUG] get zfs/07889576177877413145/super: begin
[2021-05-24 04:10:39.257][rusoto_core::proto::xml::error][DEBUG] Ignoring unknown XML element "Key" in error response.
[2021-05-24 04:10:39.257][rusoto_core::proto::xml::error][DEBUG] Ignoring unknown XML element "RequestId" in error response.
[2021-05-24 04:10:39.257][rusoto_core::proto::xml::error][DEBUG] Ignoring unknown XML element "HostId" in error response.
[2021-05-24 04:10:39.257][::object_access][DEBUG] get zfs/07889576177877413145/super: returned in 9ms
[2021-05-24 04:10:39.257][::server][ERROR] skipping PoolGUID(7889576177877413145): Failed to get zfs/07889576177877413145/super

Caused by:
    0: The specified key does not exist.
    1: The specified key does not exist.
```

example error message when object has incompatible on-disk format:
```
[2021-05-24 04:10:38.898][::server][DEBUG] prefix: zfs/15827018912487696342/
[2021-05-24 04:10:38.898][::object_access][DEBUG] get zfs/15827018912487696342/super: begin
[2021-05-24 04:10:38.907][::object_access][DEBUG] get zfs/15827018912487696342/super: returned in 9ms
[2021-05-24 04:10:38.907][::object_access][DEBUG] get zfs/15827018912487696342/super: got 31 bytes of data in additional 0ms
[2021-05-24 04:10:38.907][::server][ERROR] skipping PoolGUID(15827018912487696342): Failed to decode contents of zfs/15827018912487696342/super

Caused by:
    expected value at line 1 column 1
```