### PR TITLE
Revert zed workaround since zed crashes are now fixed (#284)"

### DIFF
--- a/etc/systemd/system/zfs-zed.service.in
+++ b/etc/systemd/system/zfs-zed.service.in
@@ -4,8 +4,7 @@ Documentation=man:zed(8)
 ConditionPathIsDirectory=/sys/module/zfs
 
 [Service]
-# DLPX-75168 -- to avoid zed crashes we run with jobs set to 1
-ExecStart=/usr/sbin/zed -F -j 1
+ExecStart=/usr/sbin/zed -F
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
### Motivation and Context
As a work-around to avoid ZED crashes, we had forced the simultaneous ZED jobs to 1.
Now that there is a fix that solves the crashes we can revert this work-around.

### Description
This reverts commit e2035aa1c11ff2b0a8d4fe375ad7030c8475048c.

### How Has This Been Tested?
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5348/