### PR TITLE
agent code cleanup

### DIFF
--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -217,7 +217,6 @@ impl ObjectAccess {
     pub async fn list_objects(
         &self,
         prefix: &str,
-        delimiter: Option<String>,
         start_after: Option<String>,
     ) -> Vec<ListObjectsV2Output> {
         let full_prefix = prefixed(prefix);
@@ -229,15 +228,12 @@ impl ObjectAccess {
         let mut continuation_token = None;
         loop {
             continuation_token = match retry(
-                &format!(
-                    "list {} (delim {:?}, after {:?})",
-                    full_prefix, delimiter, full_start_after
-                ),
+                &format!("list {} (after {:?})", full_prefix, full_start_after),
                 || async {
                     let req = ListObjectsV2Request {
                         bucket: self.bucket_str.clone(),
                         continuation_token: continuation_token.clone(),
-                        delimiter: delimiter.clone(),
+                        delimiter: Some("/".to_owned()),
                         fetch_owner: Some(false),
                         prefix: Some(full_prefix.clone()),
                         start_after: full_start_after.clone(),
@@ -259,7 +255,7 @@ impl ObjectAccess {
                     results.push(output);
                     break;
                 }
-            }
+            };
         }
         results
     }

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -260,6 +260,30 @@ impl ObjectAccess {
         results
     }
 
+    pub async fn collect_objects(&self, prefix: &str, start_after: Option<String>) -> Vec<String> {
+        let mut vec = Vec::new();
+        for output in self.list_objects(prefix, start_after).await {
+            for objects in output.contents {
+                for object in objects {
+                    vec.push(object.key.unwrap());
+                }
+            }
+        }
+        vec
+    }
+
+    pub async fn collect_prefixes(&self, prefix: &str) -> Vec<String> {
+        let mut vec = Vec::new();
+        for output in self.list_objects(prefix, None).await {
+            if let Some(prefixes) = output.common_prefixes {
+                for prefix in prefixes {
+                    vec.push(prefix.prefix.unwrap());
+                }
+            }
+        }
+        vec
+    }
+
     pub async fn object_exists(&self, key: &str) -> bool {
         let res = retry(&format!("head {}", prefixed(key)), || async {
             let req = HeadObjectRequest {

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -146,6 +146,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         // we can easily find any after the last chunk.
 
         // Delete any chunks past the logical end of the log
+        /*
         for c in self.num_chunks.. {
             let key = &format!("{}/{:020}/{:020}", self.name, self.generation, c);
             if self.pool.object_access.object_exists(&key).await {
@@ -164,6 +165,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
                 break;
             }
         }
+        */
 
         // XXX verify that there are no chunks/generations past what we deleted
 

--- a/cmd/zfs_object_agent/src/object_block_map.rs
+++ b/cmd/zfs_object_agent/src/object_block_map.rs
@@ -74,8 +74,16 @@ impl ObjectBlockMap {
             .obj
     }
 
-    pub fn obj_to_block(&self, obj: ObjectID) -> BlockID {
+    pub fn obj_to_min_block(&self, obj: ObjectID) -> BlockID {
         self.map.get(&obj).unwrap().block
+    }
+
+    pub fn obj_to_next_block(&self, obj: ObjectID) -> BlockID {
+        self.map
+            .range((Excluded(obj), Unbounded))
+            .next()
+            .unwrap()
+            .block
     }
 
     pub fn last_obj(&self) -> ObjectID {

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -611,11 +611,7 @@ impl Pool {
             list_stream.push(async move {
                 readonly_state
                     .object_access
-                    .list_objects(
-                        &prefix,
-                        Some("/".to_string()),
-                        Some(format!("{}{}", prefix, last_obj)),
-                    )
+                    .list_objects(&prefix, Some(format!("{}{}", prefix, last_obj)))
                     .await
             });
         }

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -1396,7 +1396,7 @@ async fn reclaim_frees_object(
                         .map(|(_, data)| data.len() as u32)
                         .sum::<u32>()
                 );
-                assert_le!(obj_phys.blocks_size, new_obj_size);
+                assert_ge!(obj_phys.blocks_size, new_obj_size);
                 obj_phys.blocks_size = new_obj_size;
 
                 assert_le!(obj_phys.min_block, min_block);

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -277,9 +277,7 @@ impl Server {
                 Self::send_response(&self.output, resp).await;
                 return;
             }
-            let objs = object_access
-                .list_objects("zfs/", Some("/".to_string()), None)
-                .await;
+            let objs = object_access.list_objects("zfs/", None).await;
             for res in objs {
                 if let Some(prefixes) = res.common_prefixes {
                     for prefix in prefixes {

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -283,6 +283,7 @@ impl Server {
                 let guid_str: &str = split[1];
                 if let Ok(guid64) = str::parse::<u64>(guid_str) {
                     let guid = PoolGUID(guid64);
+                    // XXX do this in parallel for all guids?
                     match Pool::get_config(&object_access, guid).await {
                         Ok(pool_config) => resp.insert(guid_str, pool_config.as_ref()).unwrap(),
                         Err(e) => {

--- a/module/os/linux/zfs/vdev_object_store.c
+++ b/module/os/linux/zfs/vdev_object_store.c
@@ -485,7 +485,7 @@ agent_begin_txg(vdev_object_store_t *vos, uint64_t txg)
 	 * might be in recovery.
 	 */
 	mutex_enter(&vos->vos_sock_lock);
-	zfs_object_store_wait(vos, VOS_SOCK_OPEN);
+	zfs_object_store_wait(vos, VOS_SOCK_READY);
 
 	nvlist_t *nv = fnvlist_alloc();
 	fnvlist_add_string(nv, AGENT_TYPE, AGENT_TYPE_BEGIN_TXG);
@@ -501,11 +501,6 @@ static void
 agent_resume_txg(vdev_object_store_t *vos, uint64_t txg)
 {
 	ASSERT(MUTEX_HELD(&vos->vos_sock_lock));
-	/*
-	 * We need to ensure that we only issue a request when the
-	 * socket is ready. Otherwise, we block here since the agent
-	 * might be in recovery.
-	 */
 	zfs_object_store_wait(vos, VOS_SOCK_OPEN);
 
 	nvlist_t *nv = fnvlist_alloc();
@@ -521,11 +516,6 @@ static void
 agent_resume_complete(vdev_object_store_t *vos)
 {
 	ASSERT(MUTEX_HELD(&vos->vos_sock_lock));
-	/*
-	 * We need to ensure that we only issue a request when the
-	 * socket is ready. Otherwise, we block here since the agent
-	 * might be in recovery.
-	 */
 	zfs_object_store_wait(vos, VOS_SOCK_OPEN);
 
 	nvlist_t *nv = fnvlist_alloc();


### PR DESCRIPTION
- restructure get_object() to directly pass data to readers that come in while a read is in progress
- list_objects(): remove delimiter parameter (it's always `"/"`)
- add helper functions collect_objects() and collect_prefixes() (based on list_objects()), which simplifies callers
- add DataObjectPhys::get_from_key() which allows removal of string processing from get_recovered_objects()
- restructure iteration code in resume_complete() to decrease mutability and `if` statements
- undo uncommitted object consolidation, add assertions to ensure that we can delete to-be-emptied objects without reading them
- begin_txg needs to wait for READY