### PR TITLE
clean up ObjectBlockMap

### DIFF
--- a/cmd/zfs_object_agent/src/object_block_map.rs
+++ b/cmd/zfs_object_agent/src/object_block_map.rs
@@ -3,10 +3,11 @@ use more_asserts::*;
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::ops::Bound::*;
+use std::sync::RwLock;
 
 #[derive(Debug)]
 pub struct ObjectBlockMap {
-    map: BTreeSet<ObjectBlockMapEntry>,
+    map: RwLock<BTreeSet<ObjectBlockMapEntry>>,
 }
 
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Copy, Clone)]
@@ -30,13 +31,13 @@ impl Borrow<BlockID> for ObjectBlockMapEntry {
 impl ObjectBlockMap {
     pub fn new() -> Self {
         ObjectBlockMap {
-            map: BTreeSet::new(),
+            map: RwLock::new(BTreeSet::new()),
         }
     }
 
     pub fn verify(&self) {
         let mut prev_ent_opt: Option<ObjectBlockMapEntry> = None;
-        for ent in self.map.iter() {
+        for ent in self.map.read().unwrap().iter() {
             if let Some(prev_ent) = prev_ent_opt {
                 assert_gt!(ent.object, prev_ent.object);
                 assert_gt!(ent.block, prev_ent.block);
@@ -45,29 +46,32 @@ impl ObjectBlockMap {
         }
     }
 
-    pub fn insert(&mut self, object: ObjectID, block: BlockID) {
+    pub fn insert(&self, object: ObjectID, block: BlockID) {
         // verify that this block is between the existing entries blocks
-        let prev_ent_opt = self.map.range((Unbounded, Excluded(object))).next_back();
+        let mut map = self.map.write().unwrap();
+        let prev_ent_opt = map.range((Unbounded, Excluded(object))).next_back();
         if let Some(prev_ent) = prev_ent_opt {
             assert_lt!(prev_ent.block, block);
         }
-        let next_ent_opt = self.map.range((Excluded(object), Unbounded)).next();
+        let next_ent_opt = map.range((Excluded(object), Unbounded)).next();
         if let Some(next_ent) = next_ent_opt {
             assert_gt!(next_ent.block, block);
         }
         // verify that this object is not yet in the map
-        assert!(!self.map.contains(&object));
+        assert!(!map.contains(&object));
 
-        self.map.insert(ObjectBlockMapEntry { object, block });
+        map.insert(ObjectBlockMapEntry { object, block });
     }
 
-    pub fn remove(&mut self, object: ObjectID) {
-        let removed = self.map.remove(&object);
+    pub fn remove(&self, object: ObjectID) {
+        let removed = self.map.write().unwrap().remove(&object);
         assert!(removed);
     }
 
     pub fn block_to_object(&self, block: BlockID) -> ObjectID {
         self.map
+            .read()
+            .unwrap()
             .range((Unbounded, Included(block)))
             .next_back()
             .unwrap()
@@ -75,11 +79,13 @@ impl ObjectBlockMap {
     }
 
     pub fn object_to_min_block(&self, object: ObjectID) -> BlockID {
-        self.map.get(&object).unwrap().block
+        self.map.read().unwrap().get(&object).unwrap().block
     }
 
     pub fn object_to_next_block(&self, object: ObjectID) -> BlockID {
         self.map
+            .read()
+            .unwrap()
             .range((Excluded(object), Unbounded))
             .next()
             .unwrap()
@@ -88,6 +94,8 @@ impl ObjectBlockMap {
 
     pub fn last_object(&self) -> ObjectID {
         self.map
+            .read()
+            .unwrap()
             .iter()
             .next_back()
             .unwrap_or(&ObjectBlockMapEntry {
@@ -98,10 +106,15 @@ impl ObjectBlockMap {
     }
 
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.map.read().unwrap().len()
     }
 
-    pub fn iter(&self) -> std::collections::btree_set::Iter<ObjectBlockMapEntry> {
-        self.map.iter()
+    pub fn for_each<CB>(&self, mut f: CB)
+    where
+        CB: FnMut(&ObjectBlockMapEntry),
+    {
+        for ent in self.map.read().unwrap().iter() {
+            f(ent);
+        }
     }
 }


### PR DESCRIPTION
Use the "interior mutability" design pattern to move the locking into
the ObjectBlockMap itself, rather than its consumer, Pool.
