### PR TITLE
Fix for assertion failure: vos->vos_sock == NULL (0xffffffffffffffff == 0x0)

### DIFF
--- a/etc/systemd/system/zfs-object-agent.service.in
+++ b/etc/systemd/system/zfs-object-agent.service.in
@@ -5,7 +5,7 @@ Before=zfs-import-cache.service
 
 [Service]
 Environment="RUST_BACKTRACE=1"
-ExecStart=/sbin/zfs_object_agent
+ExecStart=/sbin/zfs_object_agent -v
 Restart=on-abort
 
 [Install]

--- a/module/os/linux/zfs/vdev_object_store.c
+++ b/module/os/linux/zfs/vdev_object_store.c
@@ -841,7 +841,7 @@ vdev_object_store_socket_open(vdev_t *vd)
 	    vos->vos_sock == INVALID_SOCKET) {
 
 		mutex_enter(&vos->vos_lock);
-		VERIFY3P(vos->vos_sock, ==, NULL);
+		VERIFY3P(vos->vos_sock, ==, INVALID_SOCKET);
 
 		int error = zfs_object_store_open(vos, vd->vdev_path,
 		    vdev_object_store_open_mode(

--- a/module/os/linux/zfs/vdev_object_store.c
+++ b/module/os/linux/zfs/vdev_object_store.c
@@ -384,7 +384,7 @@ agent_io_block_alloc(zio_t *zio)
 	fnvlist_add_uint64(nv, AGENT_BLKID, blockid);
 	zfs_dbgmsg("agent_io_block_alloc(guid=%llu blkid=%llu len=%llu) %s",
 	    spa_guid(zio->io_spa), blockid, zio->io_size,
-	    zio->io_type == ZIO_TYPE_WRITE ? "WRITE" : "READ" );
+	    zio->io_type == ZIO_TYPE_WRITE ? "WRITE" : "READ");
 	return (nv);
 }
 


### PR DESCRIPTION
The check "vos_sock == NULL" should have been "vos_sock == INVALID_SOCKET".
zdb blows up because of this.
```
delphix@ip-10-110-202-140:~$ sudo zdb ztest
vos->vos_sock == NULL (0xffffffffffffffff == 0x0)
ASSERT at ../../module/os/linux/zfs/vdev_object_store.c:844:vdev_object_store_socket_open()Aborted
delphix@ip-10-110-202-140:~$ 
```
Tested the fix to validate that zdb is able to access the object store with the fix.

```
delphix@mj-zdb:~$ sudo zpool create -o object-endpoint=https://s3-us-west-2.amazonaws.com  -o object-region=us-west-2  -o object-credentials-location=file:///etc/zfs/zpool_credentials  ztest25 s3 cloudburst-data-2
delphix@mj-zdb:~$ sudo zpool export ztest25
delphix@mj-zdb:~$ sudo zdb -bcc -G -d -Y -e -y  -a https://s3-us-west-2.amazonaws.com -g us-west-2 -B cloudburst-data-2 -f file:///etc/zfs/zpool_credentials  ztest25 
Verifying deleted livelist entries
Verifying metaslab entries
verifying concrete vdev 0, metaslab 0 of 1 ...
Dataset mos [META], ID 0, cr_txg 4, 23K, 38 objects
Dataset ztest25 [ZPL], ID 54, cr_txg 1, 11.5K, 6 objects
Verified large_blocks feature refcount of 0 is correct
Verified large_dnode feature refcount of 0 is correct
Verified sha512 feature refcount of 0 is correct
Verified skein feature refcount of 0 is correct
Verified edonr feature refcount of 0 is correct
Verified userobj_accounting feature refcount of 1 is correct
Verified encryption feature refcount of 0 is correct
Verified project_quota feature refcount of 1 is correct
Verified redaction_bookmarks feature refcount of 0 is correct
Verified redacted_datasets feature refcount of 0 is correct
Verified bookmark_written feature refcount of 0 is correct
Verified livelist feature refcount of 0 is correct
Verified zstd_compress feature refcount of 0 is correct
Verified device_removal feature refcount of 0 is correct
Verified indirect_refcount feature refcount of 0 is correct

Skipping leak detection for object-store based zpool.


Traversing all blocks to verify checksums ...


	bp count:                    52
	ganged count:                 0
	bp logical:             1040896      avg:  20017
	bp physical:              35328      avg:    679     compression:  29.46
	bp allocated:             35328      avg:    679     compression:  29.46
	bp deduped:                   0    ref>1:      0   deduplication:   1.00
	Normal class:                 0     used:  0.00%

	additional, non-pointer bps of type 0:         25
<snip>
```

Note: I threw in a couple minor fixes into the mix, one per commit.
zdb (and import) keeps hitting a partial read scenario; a retry loop fixes it.
While we might want to rethink this later, it seems useful for the object agent to start in verbose mode.