### PR TITLE
fix reissuing issues

### DIFF
--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -464,11 +464,6 @@ struct vdev {
 	zfs_ratelimit_t vdev_delay_rl;
 	zfs_ratelimit_t vdev_deadman_rl;
 	zfs_ratelimit_t vdev_checksum_rl;
-
-	/*
-	 * For now, we associate this with a vdev.
-	 */
-	struct socket *sock;
 };
 
 #define	VDEV_PAD_SIZE		(8 << 10)
@@ -614,10 +609,11 @@ extern vdev_ops_t vdev_spare_ops;
 extern vdev_ops_t vdev_indirect_ops;
 extern vdev_ops_t vdev_object_store_ops;
 
-void object_store_begin_txg(spa_t *, uint64_t);
-void object_store_end_txg(spa_t *, nvlist_t *, uint64_t);
+void object_store_begin_txg(vdev_t *, uint64_t);
+void object_store_end_txg(vdev_t *, nvlist_t *, uint64_t);
 void object_store_free_block(vdev_t *, uint64_t, uint64_t);
 void object_store_flush_writes(spa_t *);
+void object_store_restart_agent(vdev_t *vd);
 
 /*
  * Common size functions

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -9235,7 +9235,7 @@ spa_sync(spa_t *spa, uint64_t txg)
 	VERIFY(spa_writeable(spa));
 
 	if (!spa_normal_class(spa)->mc_ops->msop_block_based) {
-		object_store_begin_txg(spa, txg);
+		object_store_begin_txg(spa->spa_root_vdev->vdev_child[0], txg);
 	}
 
 	/*

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1934,11 +1934,10 @@ retry:
 
 	ASSERT3U(txg, <=, spa->spa_final_txg);
 
-	if (spa->spa_root_vdev->vdev_child[0]->vdev_ops ==
-	    &vdev_object_store_ops) {
+	if (svd[0]->vdev_ops == &vdev_object_store_ops) {
 		nvlist_t *label = spa_config_generate(spa,
-		    spa->spa_root_vdev->vdev_child[0], txg, B_FALSE);
-		object_store_end_txg(spa, label, txg);
+		    svd[0], txg, B_FALSE);
+		object_store_end_txg(svd[0], label, txg);
 		return (0);
 	}
 

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -47,6 +47,8 @@
 #include <sys/vdev_impl.h>
 #include <sys/dmu_objset.h>
 #include <sys/dsl_dataset.h>
+#include <sys/metaslab_impl.h>
+#include <sys/spa_impl.h>
 #include <sys/fs/zfs.h>
 
 uint32_t zio_injection_enabled = 0;
@@ -174,8 +176,14 @@ zio_handle_panic_injection(spa_t *spa, char *tag, uint64_t type)
 			continue;
 
 		if (handler->zi_record.zi_type == type &&
-		    strcmp(tag, handler->zi_record.zi_func) == 0)
-			panic("Panic requested in function %s\n", tag);
+		    strcmp(tag, handler->zi_record.zi_func) == 0) {
+			if (spa_normal_class(spa)->mc_ops->msop_block_based) {
+				panic("Panic requested in function %s\n", tag);
+			} else {
+				vdev_t *vd = spa->spa_root_vdev->vdev_child[0];
+				object_store_restart_agent(vd);
+			}
+		}
 	}
 
 	rw_exit(&inject_lock);


### PR DESCRIPTION
This PR will replay the `end_txg` request if we need to resume at the end of spa_sync. In addition, it changes our serial waiters to ensure we wake up the correct serial waiters when we are resuming.

This also add `zinject` points to force a agent failure at pre-determined points. The points are defined to force an agent crash before we connect, or after connection. Here's an example:

```
root@gwilson-zfs:~# zinject -p agent_request_zio test 1
Added handler 2 with the following properties:
  pool: test
  panic function: agent_request_zio
```
This will force the agent to restart just prior to an I/O being issued on the socket:
```
[2021-05-28 18:59:25.337][::pool][DEBUG] TXG(11): writing ObjectID(20): blocks=7 bytes=6656 min=BlockID(105)
[2021-05-28 18:59:25.337][::pool][DEBUG] ObjectID(20): serialized 7 blocks in 6828 bytes in 0ms
[2021-05-28 18:59:25.337][::object_access][DEBUG] put zfs/13340201102838791387/data/020/00000000000000000020 (6828 bytes): begin
[2021-05-28 18:59:25.390][::object_access][DEBUG] put zfs/13340201102838791387/data/020/00000000000000000020 (6828 bytes): returned in 53ms
thread 'zoa' panicked at 'bad type "exit agent" in request {"Type": Str("exit agent")}', src/server.rs:202:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
To remove the fault injection:
```
root@gwilson-zfs:~# zinject
 ID  POOL             FUNCTION
---  ---------------  ----------------
  2  test             agent_request_zio
root@gwilson-zfs:~# zinject -c 2
removed handler 2
```
