### PR TITLE
More robust zoa_test list|delete

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -22,6 +22,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,13 +2019,18 @@ dependencies = [
 name = "zoa_test"
 version = "0.1.0"
 dependencies = [
+ "async-recursion",
  "chrono",
  "futures",
+ "lazy_static",
  "libzoa",
  "nvpair",
  "rand",
  "rusoto_core",
  "rusoto_s3",
  "rust-s3",
+ "serde",
+ "serde_bytes",
+ "serde_json",
  "tokio",
 ]

--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -2008,6 +2008,7 @@ dependencies = [
 name = "zoa_test"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "futures",
  "libzoa",
  "nvpair",

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -15,3 +15,4 @@ rusoto_core = "0.46.0"
 rusoto_s3 = "0.46.0"
 rust-s3 = "0.27.0-rc1"
 tokio = { version = "1.4", features = ["full"] }
+chrono = "0.4.19"

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -16,3 +16,8 @@ rusoto_s3 = "0.46.0"
 rust-s3 = "0.27.0-rc1"
 tokio = { version = "1.4", features = ["full"] }
 chrono = "0.4.19"
+async-recursion = "0.3.2"
+lazy_static = "1.4.0"
+serde = { version = "1.0.125", features = ["derive"] }
+serde_bytes = "0.11"
+serde_json = "1.0.64"

--- a/cmd/zfs_object_agent/client/src/main.rs
+++ b/cmd/zfs_object_agent/client/src/main.rs
@@ -1,9 +1,14 @@
+//use crate::object_access::ObjectAccess;
+use async_recursion::async_recursion;
 use chrono::prelude::*;
 use chrono::DateTime;
 use client::Client;
 use futures::future::*;
+use lazy_static::lazy_static;
 use libzoa::base_types::*;
 use libzoa::object_access;
+use libzoa::object_access::ObjectAccess;
+use libzoa::pool::*;
 use nvpair::*;
 use rand::prelude::*;
 use rusoto_core::ByteStream;
@@ -27,6 +32,23 @@ const REGION: &str = "us-west-2";
 const BUCKET_NAME: &str = "cloudburst-data-2";
 const POOL_NAME: &str = "testpool";
 const POOL_GUID: u64 = 1234;
+const AWS_DELETION_BATCH_SIZE: usize = 1000;
+
+lazy_static! {
+    static ref AWS_PREFIX: String = match env::var("AWS_PREFIX") {
+        Ok(val) => format!("{}/", val),
+        Err(_) => "".to_string(),
+    };
+    static ref AWS_ACCESS_KEY_ID: String = env::var("AWS_ACCESS_KEY_ID")
+        .expect("the AWS_ACCESS_KEY_ID environment variable must be set");
+    static ref AWS_SECRET_ACCESS_KEY: String = env::var("AWS_SECRET_ACCESS_KEY")
+        .expect("the AWS_SECRET_ACCESS_KEY environment variable must be set");
+    static ref AWS_CREDENTIALS: String = format!(
+        "{}:{}",
+        AWS_ACCESS_KEY_ID.clone(),
+        AWS_SECRET_ACCESS_KEY.clone()
+    );
+}
 
 async fn do_s3(bucket: &Bucket) -> Result<(), Box<dyn Error>> {
     let key = "mahrens/test.file2";
@@ -386,7 +408,9 @@ async fn do_delete_impl(bucket: &Bucket, min_age_days: i64) -> Result<(), Box<dy
 }
 
 async fn do_delete(bucket: &Bucket, args: &Vec<String>) -> Result<(), Box<dyn Error>> {
-    let min_age_days: i64 = get_int_param(args, 2, 0);
+    let min_age_days: i64 = get_int_param(args, 2, -1);
+    assert!(min_age_days < 0, "Usage: zoa_test delete <number-of-days>");
+
     do_delete_impl(&bucket, min_age_days).await.unwrap();
 
     Ok(())
@@ -425,6 +449,253 @@ fn do_nvpair() {
     write_file_as_bytes("./zpool.cache.rust", &newbuf);
 }
 
+fn get_object_access() -> ObjectAccess {
+    ObjectAccess::new(ENDPOINT, REGION, BUCKET_NAME, &AWS_CREDENTIALS.clone())
+}
+
+fn strip_prefix(prefix: &str) -> &str {
+    if prefix.starts_with(AWS_PREFIX.as_str()) {
+        &prefix[AWS_PREFIX.len()..]
+    } else {
+        prefix
+    }
+}
+struct ListObject {
+    key: String,
+    last_modified: String,
+}
+
+#[async_recursion]
+async fn list_objects(
+    object_access: &ObjectAccess,
+    prefix: &str,
+    recursive: bool,
+) -> Vec<ListObject> {
+    // Strip aws_prefix as object_access adds it back automatically.
+    let stripped_prefix = strip_prefix(prefix);
+    let mut vec: Vec<ListObject> = Vec::new();
+
+    for output in object_access.list_objects(&stripped_prefix, None).await {
+        for objects in output.contents {
+            for object in objects {
+                let o = ListObject {
+                    key: object.key.unwrap(),
+                    last_modified: object.last_modified.unwrap(),
+                };
+                vec.push(o);
+            }
+        }
+
+        if !recursive {
+            continue;
+        }
+
+        // Recursively call list_objects for each prefix in common_prefixes.
+        for object_prefixs in output.common_prefixes {
+            for object_prefix in object_prefixs {
+                let objects =
+                    list_objects(&object_access, &object_prefix.prefix.unwrap(), true).await;
+                for object in objects {
+                    let o = ListObject {
+                        key: object.key,
+                        last_modified: object.last_modified,
+                    };
+                    vec.push(o);
+                }
+            }
+        }
+    }
+
+    vec
+}
+
+fn print_list_objects(objects: Vec<ListObject>) {
+    for object in objects {
+        let mod_time = DateTime::parse_from_rfc3339(&object.last_modified).unwrap();
+        println!("{:30}  {}", mod_time, object.key);
+    }
+}
+
+async fn get_prefixes(object_access: &ObjectAccess, prefix: &str) -> Vec<String> {
+    let mut vec: Vec<String> = Vec::new();
+
+    for prefix in object_access.collect_prefixes(strip_prefix(prefix)).await {
+        vec.push(prefix);
+    }
+
+    vec
+}
+
+fn get_super_object(objects: &Vec<ListObject>) -> String {
+    let mut super_object: String = "-".to_string();
+
+    for object in objects {
+        if object.key.ends_with("/super") {
+            super_object = object.key.clone();
+            break;
+        }
+    }
+
+    super_object
+}
+
+fn get_super_timestamp(objects: &Vec<ListObject>) -> String {
+    let mut mod_time: String = "-".to_string();
+
+    for object in objects {
+        if object.key.ends_with("/super") {
+            mod_time = object.last_modified.clone();
+            break;
+        }
+    }
+
+    mod_time
+}
+
+async fn decode_super(object_access: &ObjectAccess, super_object: &str, guid: PoolGUID) -> String {
+    let pool: String;
+    match Pool::get_config(&object_access, guid).await {
+        Ok(pool_config) => {
+            let name = pool_config.lookup_string("name").unwrap();
+            let hostname = pool_config.lookup_string("hostname").unwrap();
+            pool = format!("guid:{:?} name:{:?} host:{:?}", guid, name, hostname);
+        }
+        Err(_e) => {
+            /*
+             * XXX Pool::get_config() only works for pools under the AWS_PREFIX because it assumes the
+             * path to the "super" object.
+             */
+            pool = if AWS_PREFIX.len() == 0 && !super_object.starts_with("zfs/") {
+                format!("guid:{:?} (pool inside an alt AWS_PREFIX).", guid)
+            } else {
+                format!("guid:{:?} unknown format.", guid)
+            };
+        }
+    }
+
+    format!("{}\n\tsuper:{}", pool, super_object)
+}
+
+async fn get_pool_prefixes(object_access: &ObjectAccess) -> Vec<String> {
+    let mut vec: Vec<String> = Vec::new();
+    let prefix_list = get_prefixes(&object_access, "").await;
+    println!("prefix_list {:?}", prefix_list);
+
+    for prefix in prefix_list {
+        if prefix.eq("zfs/") || prefix.ends_with("/zfs/") {
+            vec.push(prefix);
+        } else if prefix.ne("/") {
+            vec.push(format!("{}{}", prefix, "zfs/"));
+        }
+    }
+
+    vec
+}
+
+enum PoolProcessOp {
+    ListSuperOnly,
+    ListAllObjects,
+    DeletePool,
+}
+
+impl PoolProcessOp {
+    fn is_delete(&self) -> bool {
+        match self {
+            PoolProcessOp::ListAllObjects => false,
+            PoolProcessOp::ListSuperOnly => false,
+            PoolProcessOp::DeletePool => true,
+        }
+    }
+
+    fn is_list_all_objects(&self) -> bool {
+        match self {
+            PoolProcessOp::ListAllObjects => true,
+            PoolProcessOp::ListSuperOnly => false,
+            _ => false,
+        }
+    }
+}
+
+/*
+ * Common routine for deleting and listing pools and objects in a pool.
+ * all_objects: if false only "super" objects are listed; else all objects are listed.
+ * destroy: if true, instead of listing, the pool objects are destroyed.
+ * min_age_days: minimum age for destroying a pool.
+ */
+async fn find_and_process_pools(
+    op: PoolProcessOp,
+    min_age_days: i64,
+) -> Result<(), Box<dyn Error>> {
+    let object_access = get_object_access();
+
+    println!("Looking for pools...");
+    for pool_prefix in get_pool_prefixes(&object_access).await {
+        println!("Looking for pools UNDER {}...", pool_prefix);
+
+        for prefix in get_prefixes(&object_access, &pool_prefix).await {
+            let split: Vec<&str> = prefix.rsplitn(3, '/').collect();
+            let guid_str: &str = split[1];
+            if let Ok(guid64) = str::parse::<u64>(guid_str) {
+                let guid = PoolGUID(guid64);
+
+                // Get only super from the pool.
+                let objects = list_objects(&object_access, &prefix, false).await;
+                let timestamp = get_super_timestamp(&objects);
+                let super_object = get_super_object(&objects);
+                println!(
+                    "\n{:30} {}",
+                    timestamp,
+                    decode_super(&object_access, super_object.as_str(), guid).await,
+                );
+
+                if op.is_delete() {
+                    if !has_expired(timestamp.as_str(), min_age_days) {
+                        println!(
+                            "Skipping  pool deletion as it is not {} days old.",
+                            min_age_days
+                        );
+                        continue;
+                    }
+
+                    let all_objects = list_objects(&object_access, &prefix, true).await;
+                    let mut keys: Vec<String> = Vec::new();
+
+                    for object in all_objects {
+                        keys.push(strip_prefix(object.key.as_str()).to_string());
+                    }
+                    assert!(keys.len() > 0);
+                    println!("Deleting {} objects in the pool.", keys.len());
+
+                    /*
+                     * XXX: Is there a better way than orming an array of chunks and reconstrucing a vector for each
+                     * chunk?
+                     */
+                    for chunk in keys.chunks(AWS_DELETION_BATCH_SIZE) {
+                        object_access.delete_objects(chunk.to_vec()).await;
+                    }
+                } else if op.is_list_all_objects() {
+                    // Lookup all objects in the pool.
+                    let all_objects = list_objects(&object_access, &prefix, true).await;
+                    print_list_objects(all_objects);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn list_pools(op: PoolProcessOp) -> Result<(), Box<dyn Error>> {
+    find_and_process_pools(op, 0).await
+}
+
+async fn destroy_old_pools(args: &Vec<String>) -> Result<(), Box<dyn Error>> {
+    let min_age_days: i64 = get_int_param(args, 2, -1);
+    assert!(min_age_days >= 0, "Usage: zoa_test destroy_old_pools <number-of-days>");
+
+    find_and_process_pools(PoolProcessOp::DeletePool, min_age_days).await
+}
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -444,6 +715,9 @@ async fn main() {
         "s3_rusoto" => do_s3_rusoto().await.unwrap(),
         "list" => do_list(&bucket, &args).await.unwrap(),
         "delete" => do_delete(&bucket, &args).await.unwrap(),
+        "list_pools" => list_pools(PoolProcessOp::ListSuperOnly).await.unwrap(),
+        "list_pool_objects" => list_pools(PoolProcessOp::ListAllObjects).await.unwrap(),
+        "destroy_old_pools" => destroy_old_pools(&args).await.unwrap(),
         "create" => do_create().await.unwrap(),
         "write" => do_write().await.unwrap(),
         "read" => do_read().await.unwrap(),

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -225,7 +225,8 @@ impl ObjectAccess {
         prefix: &str,
         start_after: Option<String>,
     ) -> Vec<ListObjectsV2Output> {
-        self.list_objects_impl(prefix, start_after, None).await
+        self.list_objects_impl(prefix, start_after, Some("/".to_owned()))
+            .await
     }
 
     pub async fn list_objects_impl(


### PR DESCRIPTION
`zoa_test delete` fails with the oom-killer killing it when there are many (over 15K does the trick). `zoa_test list` also has difficulties with listing many objects.

The problem is that we fetch all the objects in one fell swoop and fire off futures all in one go. What this change does is two things. It processes the fetched list in batches. It also does a paged fetch (`bucket.list_page()` as opposed to `bucket.list()`).

Also added is the ability to list|delete objects older than a specified number of days. This can be used to cleanup older objects that are no longer in use. We have about 3.5 million objects older than 10 days that can potentially be cleaned up.

```
root@mj-zdb-2:~# export AWS_PREFIX=123456789
root@mj-zdb-2:~# /export/home/delphix/zfs/cmd/zfs_object_agent/target/debug/zoa_test list 15 | wc -l
1
root@mj-zdb-2:~# /export/home/delphix/zfs/cmd/zfs_object_agent/target/debug/zoa_test list 10 | wc -l
15314
root@mj-zdb-2:~# /export/home/delphix/zfs/cmd/zfs_object_agent/target/debug/zoa_test list 10 | tail -4
2021-05-14 19:23:42 +00:00      123456789/zfs/9132032266669162907/txg/996
2021-05-14 19:23:43 +00:00      123456789/zfs/9132032266669162907/txg/997
2021-05-14 19:23:44 +00:00      123456789/zfs/9132032266669162907/txg/998
2021-05-14 19:23:45 +00:00      123456789/zfs/9132032266669162907/txg/999
root@mj-zdb-2:~# 
root@mj-zdb-2:~# /export/home/delphix/zfs/cmd/zfs_object_agent/target/debug/zoa_test delete 
<snip>
finished deleting object 123456789/zfs/9132032266669162907/txg/986 in 9934ms
finished deleting object 123456789/zfs/9132032266669162907/txg/989 in 9934ms
finished deleting object 123456789/zfs/9132032266669162907/txg/993 in 9934ms
deleted 916, skipped 0 objects in 10492ms; .
root@mj-zdb-2:~# 
root@mj-zdb-2:~# unset AWS_PREFIX
root@mj-zdb-2:~# time /export/home/delphix/zfs/cmd/zfs_object_agent/target/debug/zoa_test list 10 > list

real    67m57.498s
user    35m20.538s
sys     2m11.543s
root@mj-zdb-2:~# wc -l list 
3523343 list
root@mj-zdb-2:~# 
```

Next step would be to enhance this tool to look for and destroy old pools that are no longer in use.
Matt Ahrens suggested this: "look for super objects that haven’t been modified in the past X days and then delete all the objects in the pool".