### PR TITLE
update agent PoolSyncingState locking strategy

### DIFF
--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -354,13 +354,13 @@ impl ObjectAccess {
     }
 
     pub async fn delete_object(&self, key: &str) {
-        self.delete_objects(vec![key.to_string()]).await;
+        self.delete_objects(&[key.to_string()]).await;
     }
 
     // return if retry needed
     // XXX unfortunate that this level of retry can't be handled by retry()
     // XXX ideally we would only retry the failed deletions, not all of them
-    async fn delete_objects_impl(&self, keys: &Vec<String>) -> bool {
+    async fn delete_objects_impl(&self, keys: &[String]) -> bool {
         let msg = format!(
             "delete {} objects including {}",
             keys.len(),
@@ -402,7 +402,7 @@ impl ObjectAccess {
     // prefixed already, to avoid creating new ObjectIdentifiers
     // Note: AWS supports up to 1000 keys per delete_objects request.
     // XXX should we split them up here?
-    pub async fn delete_objects(&self, keys: Vec<String>) {
-        while self.delete_objects_impl(&keys).await {}
+    pub async fn delete_objects(&self, keys: &[String]) {
+        while self.delete_objects_impl(keys).await {}
     }
 }

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -928,6 +928,8 @@ impl Pool {
             if flush_block < next_block {
                 do_flush = true;
                 syncing_state.pending_flushes.remove(&flush_block);
+            } else {
+                break;
             }
         }
         if do_flush {

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -895,10 +895,10 @@ impl Pool {
                 shared_state
                     .object_access
                     .delete_objects(
-                        objects
+                        &objects
                             .iter()
                             .map(|o| DataObjectPhys::key(shared_state.guid, *o))
-                            .collect(),
+                            .collect::<Vec<_>>(),
                     )
                     .await;
             }

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -667,12 +667,6 @@ impl Pool {
     }
 
     pub async fn resume_complete(&self) {
-        // XXX we need to wait for all writes to be added to
-        // pending_unordered_writes, but there's no way to do that
-        // XXX should no longer be needed since write_block() is called
-        // synchronously from the main Server task, so all writes have already been added to pending_unordered_writes
-        //sleep(Duration::from_secs(1)).await;
-
         let state = &self.state;
         let txg = self.state.with_syncing_state(|syncing_state| {
             // verify that we're in resuming state

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -139,12 +139,12 @@ impl Server {
                         server.begin_txg(txg);
                     }
                     "resume txg" => {
-                        debug!("got request: {:?}", nvl);
+                        info!("got request: {:?}", nvl);
                         let txg = TXG(nvl.lookup_uint64("TXG").unwrap());
                         server.resume_txg(txg);
                     }
                     "resume complete" => {
-                        debug!("got request: {:?}", nvl);
+                        info!("got request: {:?}", nvl);
                         server.resume_complete().await;
                     }
                     "flush writes" => {

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -349,9 +349,7 @@ impl Server {
     fn flush_writes(&mut self) {
         let pool = self.pool.as_ref().unwrap().clone();
         let max_blockid = self.max_blockid;
-        tokio::spawn(async move {
-            pool.initiate_flush(max_blockid);
-        });
+        pool.initiate_flush(max_blockid);
     }
 
     // sends response
@@ -421,9 +419,7 @@ impl Server {
     /// initiate free.  No response.  Does not block.  Completes when the current txg is ended.
     fn free_block(&mut self, block: BlockID, size: u32) {
         let pool = self.pool.as_ref().unwrap().clone();
-        tokio::spawn(async move {
-            pool.free_block(block, size);
-        });
+        pool.free_block(block, size);
     }
 
     /// initiate read, sends response when completed.  Does not block.


### PR DESCRIPTION
- flush all logs concurrently
- rename pool:PoolSharedState -> shared_state
- delete_objects() can take a slice
- Don't need Arc with Bytes
- Change locking strategy: `syncing_state: std::sync::Mutex<Option<PoolSyncingState>>,` and `with_syncing_state()` helper function to obtain lock & run closure
This lets us serialize the initial processing of write_block(), which lets us remove the race condition at the beginning of `resume_complete()` (and sleep(1s) to work around it)
- fix a bug in `check_pending_flushes()`