### PR TITLE
DOSE-257 Killing zfs-object-agent service doesn't always restart the service

### DIFF
--- a/etc/systemd/system/zfs-object-agent.service.in
+++ b/etc/systemd/system/zfs-object-agent.service.in
@@ -5,7 +5,7 @@ Before=zfs-import-cache.service
 
 [Service]
 Environment="RUST_BACKTRACE=1"
-ExecStart=/sbin/zfs_object_agent -v
+ExecStart=/sbin/zfs_object_agent -vv
 Restart=always
 
 [Install]

--- a/etc/systemd/system/zfs-object-agent.service.in
+++ b/etc/systemd/system/zfs-object-agent.service.in
@@ -6,7 +6,7 @@ Before=zfs-import-cache.service
 [Service]
 Environment="RUST_BACKTRACE=1"
 ExecStart=/sbin/zfs_object_agent -v
-Restart=on-abort
+Restart=always
 
 [Install]
 WantedBy=zfs-import.target


### PR DESCRIPTION
- Make the agent restart `Restart=always`.
- More verbose logging for the agent with `-vv`

Tested that the agent restarts as expected and we get verbose logs.