### PR TITLE
ZFS Object Agent chaos monkey service

### DIFF
--- a/cmd/zfs_object_agent/Makefile.am
+++ b/cmd/zfs_object_agent/Makefile.am
@@ -1,5 +1,7 @@
 sbin_PROGRAMS = zfs_object_agent zoa_test
 
+bin_SCRIPTS = scripts/zoa_chaos_monkey
+
 zfs_object_agent_SOURCES = $(wildcard server/src/*.rs src/*.rs)
 
 zoa_test_SOURCES = $(wildcard client/src/*.rs src/*.rs)

--- a/cmd/zfs_object_agent/scripts/zoa_chaos_monkey
+++ b/cmd/zfs_object_agent/scripts/zoa_chaos_monkey
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+#
+# This Chaos Monkey script kills the ZFS Object Agent process periodically
+# and may be use to test agent recovery. It sleeps for a random number of
+# seconds, between $MAX_KILL_DELAY and $MIN_KILL_DELAY . On waking up, it
+# sends a kill signal to the zfs_object_agent process and then goes back to
+# sleep again.
+#
+
+error() {
+    echo "$@" 1>&2
+}
+
+fatal() {
+    error "$@";
+    exit 1;
+}
+
+MAX="${MAX_KILL_DELAY:-300}"
+MIN="${MIN_KILL_DELAY:-30}"
+
+echo "Max kill delay: $MAX"
+echo "Min kill delay: $MIN"
+
+if [ ! "$MAX" -gt 0 ]; then
+    fatal "MAX_KILL_DELAY should be a positive integer.
+else if [ ! "$MIN" -gt 0 ]; then
+    fatal "MAX_KILL_DELAY should be a positive integer.
+fi
+
+while true; do
+    # Sleep for a random number of seconds between MIN and MAX.
+    RAND=$(awk -v MIN="$MIN" -v MAX="$MAX" \
+        'BEGIN{srand();print int(rand() * (MAX - MIN)) + MIN }')
+    echo "Sleeping for $RAND seconds."
+    sleep $RAND
+
+    AGENT_PID=$(systemctl show -p MainPID zfs-object-agent.service \
+        | cut -f 2 -d '=')
+    if [ "$AGENT_PID" -gt 0 ]; then
+        kill -s KILL $AGENT_PID
+        echo "Killed zfs_object_agent pid: ${AGENT_PID}."
+    else
+        error "agent process not found."
+    fi
+done

--- a/debian/zfsutils-linux.install
+++ b/debian/zfsutils-linux.install
@@ -7,6 +7,7 @@ lib/systemd/system/zfs.target
 lib/systemd/system/zfs-import.service
 lib/systemd/system/zfs-import.target
 lib/systemd/system/zfs-object-agent.service
+lib/systemd/system/zoa-chaos-monkey.service
 lib/systemd/system/zfs-volume-wait.service
 lib/systemd/system/zfs-volumes.target
 lib/systemd/system-preset/
@@ -34,6 +35,7 @@ sbin/zfs
 sbin/zfs_object_agent
 sbin/zoa_test
 usr/bin/zvol_wait
+usr/bin/zoa_chaos_monkey
 usr/sbin/arc_summary
 usr/sbin/arcstat
 usr/sbin/dbufstat

--- a/etc/systemd/system/Makefile.am
+++ b/etc/systemd/system/Makefile.am
@@ -13,6 +13,7 @@ systemdunit_DATA = \
 	zfs-import.target \
 	zfs-volumes.target \
 	zfs-object-agent.service \
+	zoa-chaos-monkey.service \
 	zfs.target
 
 SUBSTFILES += $(systemdpreset_DATA) $(systemdunit_DATA)

--- a/etc/systemd/system/zoa-chaos-monkey.service.in
+++ b/etc/systemd/system/zoa-chaos-monkey.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=ZFS Object Agent Chaos Monkey
+After=zfs-object-agent.service
+
+[Service]
+Type=simple
+Environment=MAX_KILL_DELAY=300
+Environment=MIN_KILL_DELAY=60
+ExecStart=/usr/bin/zoa_chaos_monkey
+Restart=on-failure

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -350,7 +350,7 @@ image which is ZFS aware.
 
 %if 0%{?_systemd}
     %define systemd --enable-systemd --with-systemdunitdir=%{_unitdir} --with-systemdpresetdir=%{_presetdir} --with-systemdmodulesloaddir=%{_modulesloaddir} --with-systemdgeneratordir=%{_systemdgeneratordir} --disable-sysvinit
-    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target zfs-object-agent.service
+    %define systemd_svcs zfs-import-cache.service zfs-import-scan.service zfs-mount.service zfs-share.service zfs-zed.service zfs.target zfs-import.target zfs-volume-wait.service zfs-volumes.target zfs-object-agent.service zoa-chaos-monkey.service
 %else
     %define systemd --enable-sysvinit --disable-systemd
 %endif


### PR DESCRIPTION
The Chaos Monkey service kills the ZFS Object Agent process periodically and may be use to test agent recovery.
It sleeps for a random number of seconds, between 60 and 300. On waking up, it sends a kill signal to the zfs_object_agent process and then goes back to sleep again.

How aggressively the process is killed may be tuned by changing the amount of time the service waits before killing the agent. This is done with a a service override (see below).

Testing:
```
delphix@mj-chaos-1:~$ sudo systemctl start zfs-object-agent.service
delphix@mj-chaos-1:~$ sudo systemctl start zoa-chaos-monkey.service
delphix@mj-chaos-1:~$ sudo systemctl status zfs-object-agent.service
● zfs-object-agent.service - ZFS object agent
   Loaded: loaded (/lib/systemd/system/zfs-object-agent.service; disabled; vendor preset: enabled)
   Active: active (running) since Sat 2021-06-05 03:23:36 UTC; 23s ago
 Main PID: 5638 (zfs_object_agen)
    Tasks: 3 (limit: 8842)
   CGroup: /system.slice/zfs-object-agent.service
           └─5638 /sbin/zfs_object_agent -vv

Jun 05 03:23:36 mj-chaos-1.dcol2 systemd[1]: Started ZFS object agent.
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.556][zfs_object_agent][ERROR] Starting ZFS Object Agent.  Local timezone is +00:00 (+00:00)
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.556][zfs_object_agent][ERROR] logging level ERROR enabled
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.556][zfs_object_agent][WARN] logging level WARN enabled
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.556][zfs_object_agent][INFO] logging level INFO enabled
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.556][zfs_object_agent][DEBUG] logging level DEBUG enabled
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.558][::server][INFO] Listening on: /run/zfs_kernel_socket
Jun 05 03:23:36 mj-chaos-1.dcol2 zfs_object_agent[5638]: [2021-06-05 03:23:36.558][::server][INFO] Listening on: /run/zfs_user_socket
delphix@mj-chaos-1:~$ sudo systemctl status zoa-chaos-monkey.service
● zoa-chaos-monkey.service - ZFS Object Agent Chaos Monkey
   Loaded: loaded (/lib/systemd/system/zoa-chaos-monkey.service; disabled; vendor preset: enabled)
  Drop-In: /etc/systemd/system/zoa-chaos-monkey.service.d
           └─override.conf
   Active: active (running) since Sat 2021-06-05 03:23:40 UTC; 24s ago
 Main PID: 5673 (zoa_chaos_monke)
    Tasks: 2 (limit: 8842)
   CGroup: /system.slice/zoa-chaos-monkey.service
           ├─5673 /bin/sh /usr/bin/zoa_chaos_monkey
           └─5687 sleep 100

Jun 05 03:23:40 mj-chaos-1.dcol2 systemd[1]: Started ZFS Object Agent Chaos Monkey.
Jun 05 03:23:40 mj-chaos-1.dcol2 zoa_chaos_monkey[5673]: Max kill delay: 300
Jun 05 03:23:40 mj-chaos-1.dcol2 zoa_chaos_monkey[5673]: Min kill delay: 60
Jun 05 03:23:40 mj-chaos-1.dcol2 zoa_chaos_monkey[5673]: Sleeping for 100 seconds.
delphix@mj-chaos-1:~$ sudo systemctl edit zoa-chaos-monkey.service
delphix@mj-chaos-1:~$ cat /etc/systemd/system/zoa-chaos-monkey.service.d/override.conf
[Service]
Environment=MAX_KILL_DELAY=30
Environment=MIN_KILL_DELAY=10
delphix@mj-chaos-1:~$ sudo systemctl restart zoa-chaos-monkey.service
delphix@mj-chaos-1:~$ 
delphix@mj-chaos-1:~$ sudo journalctl -u zfs-object-agent.service -f
-- Logs begin at Sat 2021-06-05 00:17:22 UTC. --
Jun 05 03:25:22 mj-chaos-1.dcol2 systemd[1]: zfs-object-agent.service: Scheduled restart job, restart counter is at 2.
Jun 05 03:25:22 mj-chaos-1.dcol2 systemd[1]: Stopped ZFS object agent.
Jun 05 03:25:22 mj-chaos-1.dcol2 systemd[1]: Started ZFS object agent.
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.634][zfs_object_agent][ERROR] Starting ZFS Object Agent.  Local timezone is +00:00 (+00:00)
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.634][zfs_object_agent][ERROR] logging level ERROR enabled
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.634][zfs_object_agent][WARN] logging level WARN enabled
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.634][zfs_object_agent][INFO] logging level INFO enabled
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.634][zfs_object_agent][DEBUG] logging level DEBUG enabled
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.635][::server][INFO] Listening on: /run/zfs_kernel_socket
Jun 05 03:25:22 mj-chaos-1.dcol2 zfs_object_agent[6139]: [2021-06-05 03:25:22.636][::server][INFO] Listening on: /run/zfs_user_socket
Jun 05 03:25:47 mj-chaos-1.dcol2 systemd[1]: zfs-object-agent.service: Main process exited, code=killed, status=9/KILL
Jun 05 03:25:47 mj-chaos-1.dcol2 systemd[1]: zfs-object-agent.service: Failed with result 'signal'.
Jun 05 03:25:47 mj-chaos-1.dcol2 systemd[1]: zfs-object-agent.service: Service hold-off time over, scheduling restart.
Jun 05 03:25:47 mj-chaos-1.dcol2 systemd[1]: zfs-object-agent.service: Scheduled restart job, restart counter is at 3.
Jun 05 03:25:47 mj-chaos-1.dcol2 systemd[1]: Stopped ZFS object agent.
Jun 05 03:25:47 mj-chaos-1.dcol2 systemd[1]: Started ZFS object agent.
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.634][zfs_object_agent][ERROR] Starting ZFS Object Agent.  Local timezone is +00:00 (+00:00)
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.634][zfs_object_agent][ERROR] logging level ERROR enabled
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.634][zfs_object_agent][WARN] logging level WARN enabled
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.634][zfs_object_agent][INFO] logging level INFO enabled
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.634][zfs_object_agent][DEBUG] logging level DEBUG enabled
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.635][::server][INFO] Listening on: /run/zfs_kernel_socket
Jun 05 03:25:47 mj-chaos-1.dcol2 zfs_object_agent[6215]: [2021-06-05 03:25:47.636][::server][INFO] Listening on: /run/zfs_user_socket
^C
delphix@mj-chaos-1:~$ 
delphix@mj-chaos-1:~$ sudo journalctl -u zoa-chaos-monkey.service -f
-- Logs begin at Sat 2021-06-05 00:17:22 UTC. --
Jun 05 03:24:44 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Min kill delay: 10
Jun 05 03:24:44 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Sleeping for 22 seconds.
Jun 05 03:25:06 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Killed zfs_object_agent pid: 5638.
Jun 05 03:25:06 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Sleeping for 16 seconds.
Jun 05 03:25:22 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Killed zfs_object_agent pid: 6065.
Jun 05 03:25:22 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Sleeping for 25 seconds.
Jun 05 03:25:47 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Killed zfs_object_agent pid: 6139.
Jun 05 03:25:47 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Sleeping for 15 seconds.
Jun 05 03:26:02 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Killed zfs_object_agent pid: 6215.
Jun 05 03:26:02 mj-chaos-1.dcol2 zoa_chaos_monkey[5912]: Sleeping for 29 seconds.
^C
delphix@mj-chaos-1:~$ 
```