### PR TITLE
Change chaos-monkey's kill delay to [0-300] seconds

### DIFF
--- a/cmd/zfs_object_agent/scripts/zoa_chaos_monkey
+++ b/cmd/zfs_object_agent/scripts/zoa_chaos_monkey
@@ -18,7 +18,7 @@ fatal() {
 }
 
 MAX="${MAX_KILL_DELAY:-300}"
-MIN="${MIN_KILL_DELAY:-30}"
+MIN="${MIN_KILL_DELAY:-0}"
 
 echo "Max kill delay: $MAX"
 echo "Min kill delay: $MIN"

--- a/etc/systemd/system/zoa-chaos-monkey.service.in
+++ b/etc/systemd/system/zoa-chaos-monkey.service.in
@@ -5,6 +5,6 @@ After=zfs-object-agent.service
 [Service]
 Type=simple
 Environment=MAX_KILL_DELAY=300
-Environment=MIN_KILL_DELAY=60
+Environment=MIN_KILL_DELAY=0
 ExecStart=/usr/bin/zoa_chaos_monkey
 Restart=on-failure


### PR DESCRIPTION
Change chaos-monkey's default kill delay to 0-300 seconds.

Testing:
```
delphix@mj-chaos-1:~$ sudo systemctl start zfs-object-agent.service
delphix@mj-chaos-1:~$ sudo systemctl start zoa-chaos-monkey.service
delphix@mj-chaos-1:~$ sudo journalctl -u zoa-chaos-monkey.service -f
-- Logs begin at Sat 2021-06-05 00:17:22 UTC. --
Jun 10 18:55:46 mj-chaos-1.dcol2 systemd[1]: Started ZFS Object Agent Chaos Monkey.
Jun 10 18:55:46 mj-chaos-1.dcol2 zoa_chaos_monkey[7792]: Max kill delay: 300
Jun 10 18:55:46 mj-chaos-1.dcol2 zoa_chaos_monkey[7792]: Min kill delay: 0
Jun 10 18:55:46 mj-chaos-1.dcol2 zoa_chaos_monkey[7792]: Sleeping for 274 seconds.
```