### PR TITLE
DOSE-283 allow unlimited I/O requests

### DIFF
--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -646,6 +646,9 @@ void vdev_metaslab_group_create(vdev_t *vd);
 uberblock_t *vdev_object_store_get_uberblock(vdev_t *vd);
 nvlist_t *vdev_object_store_get_config(vdev_t *vd);
 
+extern void vdev_queue_pending_add(vdev_queue_t *vq, zio_t *zio);
+extern void vdev_queue_pending_remove(vdev_queue_t *vq, zio_t *zio);
+
 /*
  * Vdev ashift optimization tunables
  */

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -465,6 +465,7 @@ struct zio {
 	metaslab_class_t *io_metaslab_class;	/* dva throttle class */
 
 	uint64_t	io_offset;
+	boolean_t	io_offset_match;
 	hrtime_t	io_timestamp;	/* submitted at */
 	hrtime_t	io_queued_timestamp;
 	hrtime_t	io_target_timestamp;

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -3497,13 +3497,6 @@ zio_object_allocate_and_issue(zio_t *zio)
 	 */
 	zio->io_pipeline &= ~ZIO_STAGE_VDEV_IO_START;
 
-	/*
-	 * Lock ensures we allocate the next block ID and send it up to the
-	 * agent before any more allocations happen.  This way we fulfill the
-	 * write ordering constraint (write requests must be in order of
-	 * increasing block IDs).
-	 */
-	mutex_enter(&mc->mc_object_store_lock);
 	spa_config_enter(spa, SCL_ALLOC|SCL_ZIO, FTAG, RW_READER);
 
 	ASSERT3U(zio->io_prop.zp_copies, ==, 1);
@@ -3538,7 +3531,6 @@ zio_object_allocate_and_issue(zio_t *zio)
 	zfs_dbgmsg("zio=%px completed io_start (off=%llu, next=%px)",
 	    zio, DVA_GET_OFFSET(&bp->blk_dva[0]), next_zio);
 #endif
-	mutex_exit(&mc->mc_object_store_lock);
 	return (zio);
 }
 


### PR DESCRIPTION
This PR allows an unlimited queue (unless we run out of memory) of outstanding I/Os. It repurposes the vdev_queue's vq_active_tree which is not used for object storage to store the pending I/Os.

With this change we are able to get ~450MB/s of sequential writes and ~140MB/s of sequential reads.