### PR TITLE
Make Rusoto source AWS access credentials via IAM EC2 instance profile

### DIFF
--- a/cmd/zfs_object_agent/Cargo.lock
+++ b/cmd/zfs_object_agent/Cargo.lock
@@ -469,6 +469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +930,7 @@ dependencies = [
  "nvpair",
  "rand",
  "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
  "seahash",
  "serde",
@@ -1503,7 +1510,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.7.0",
  "tokio",
  "tokio-native-tls",
  "url",
@@ -1592,6 +1599,21 @@ dependencies = [
  "sha2",
  "time 0.2.27",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f93005e0c3b9e40a424b50ca71886d2445cc19bb6cdac3ac84c2daff482eb59"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded 0.6.1",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1761,6 +1783,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -2389,13 +2423,16 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "chrono",
+ "clap",
  "futures",
  "lazy_static",
  "libzoa",
  "nvpair",
  "rand",
  "rusoto_core",
+ "rusoto_credential",
  "rusoto_s3",
+ "rusoto_sts",
  "rust-s3",
  "serde",
  "serde_bytes",

--- a/cmd/zfs_object_agent/Cargo.toml
+++ b/cmd/zfs_object_agent/Cargo.toml
@@ -38,6 +38,7 @@ nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rusoto_core = "0.46.0"
 rusoto_s3 = "0.46.0"
+rusoto_credential = "0.46.0"
 seahash = "4.1.0"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_bytes = "0.11"

--- a/cmd/zfs_object_agent/client/Cargo.toml
+++ b/cmd/zfs_object_agent/client/Cargo.toml
@@ -7,12 +7,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "2"
 futures = "0.3.13"
 libzoa = { path = "../" }
 nvpair = { git = "https://github.com/ahrens/rust-libzfs", branch = "work"}
 rand = "0.8.3"
 rusoto_core = "0.46.0"
 rusoto_s3 = "0.46.0"
+rusoto_sts = "0.46.0"
+rusoto_credential = "0.46.0"
 rust-s3 = "0.27.0-rc1"
 tokio = { version = "1.4", features = ["full"] }
 chrono = "0.4.19"

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -229,25 +229,18 @@ impl Server {
         let bucket_name = nvl.lookup_string("bucket").unwrap();
         let region_str = nvl.lookup_string("region").unwrap();
         let endpoint = nvl.lookup_string("endpoint").unwrap();
-        let credential_str = nvl.lookup_string("credentials").unwrap();
-
         ObjectAccess::new(
             endpoint.to_str().unwrap(),
             region_str.to_str().unwrap(),
             bucket_name.to_str().unwrap(),
-            credential_str.to_str().unwrap(),
         )
     }
 
     async fn get_pools(&mut self, nvl: &NvList) {
         let region_str = nvl.lookup_string("region").unwrap();
         let endpoint = nvl.lookup_string("endpoint").unwrap();
-        let credential_str = nvl.lookup_string("credentials").unwrap();
-        let mut client = ObjectAccess::get_client(
-            endpoint.to_str().unwrap(),
-            region_str.to_str().unwrap(),
-            credential_str.to_str().unwrap(),
-        );
+        let mut client =
+            ObjectAccess::get_client(endpoint.to_str().unwrap(), region_str.to_str().unwrap());
         let mut resp = NvList::new_unique_names();
         let mut buckets = vec![];
         if let Ok(bucket) = nvl.lookup_string("bucket") {

--- a/etc/systemd/system/zfs-object-agent.service.in
+++ b/etc/systemd/system/zfs-object-agent.service.in
@@ -5,6 +5,8 @@ Before=zfs-import-cache.service
 
 [Service]
 Environment="RUST_BACKTRACE=1"
+Environment="AWS_SECRET_ACCESS_KEY="
+Environment="AWS_ACCESS_KEY_ID="
 ExecStart=/sbin/zfs_object_agent -vv
 Restart=always
 


### PR DESCRIPTION
Update: This change is now ready for review.

----

Matt, I am posting this PR is for discussing ZOA's credential management with you.

It looks like rusoto has the ability to source AWS access credentials from multiple sources, including IAM EC2 instance profile.
See: https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md

I wrote a simple test to demonstrate this. I ran the test on my VM based on the new `OBJECT` type that devops is building.

```
delphix@ip-10-110-137-138:~/zfs/cmd/zfs_object_agent$ unset AWS_ACCESS_KEY_ID
delphix@ip-10-110-137-138:~/zfs/cmd/zfs_object_agent$ unset AWS_SECRET_ACCESS_KEY
delphix@ip-10-110-137-138:~/zfs/cmd/zfs_object_agent$ target/debug/zoa_test rusoto_role
bucket: Bucket { name: "dcoa-gparton-manoj-object-storage", region: UsWest2, credentials: Credentials { access_key: Some("ASIAST3TLR4Y6I7CRBMC"), secret_key: Some("oHVMoQN2L2Xc4hVPi5rb31y8pmanRllF5h8yLHxa"), security_token: Some("IQoJb3JpZ2luX2VjEAcaCXVzLXdlc3QtMiJIMEYCIQDwZaL+OQSFbDB4XYLKXn83SaLp4ApRhjUjqcJA7VMPrQIhALrLfv1T4W9kQKxyRNw8FiGt1GXi8KPotjvgCraMzMakKoMECND//////////wEQABoMMTgwMDkzNjg1NTUzIgxdWAHDwTQfw9SHHfkq1wPzqdRTOdfKVhDuzkrDjEW7thrnbFULRZa0JoJ3tmHZBPPtmhLJdxeYN1IAkVmxDnlve3CKIeaVMQ998fExwHRIKj5QSjUbDEz4XS/jz0Gt34rxioxFw7m5Ez/tuX52mhVw6XMRfgPRu4ZtywQLTyfygFaPstlzdxWWqb5jIsse18f7gwWtn/xYKCrMAGlb4blB7afjvzPMrjmYaRNzTX87+Guo54tnz0bu1BcLsBJ06zBscvPXlbtRCTKU3dUeq7kMDXexlrpEI3SHnx77uxLvj+qEVBuUU0YZ7QJzI7n5Q08pa/ftihilCmrmrTam1r6yuZs5Q5bp6Uapmf00rG1ggeSjHPbrHr0J/aScnDS/I+lMexcmSlMR+gvyjDyb0DYfrk4CrCwy/5mgRB7ITWHbZ8NfmeB5EyQxQnptEEUI/lyNxSDQFCm2UVU5AelId17SZYLwWU7UlCI5nLmJHa66EldXRVGh2UZBHoKCXKSR8i8f2RRCHudDKvXCrv7G5LxVY6v7gGM8yI9VKbXGRnCPfm2iRqjgBGlKkZePIXPtjzGbM0J1Oug6lFkI2/dO7mNAcx/+C1ZBfFEDkArS9MW1YUV35bkzT1RZFSkaQGHLNgAsAJiA6MYwsZfGhgY6pAEkIwNv+IscYNOUb0zlClOd8VjJOtcrYCixPxOl36fbMpbiXfNS0yD+xzjEXDEv20zUnGgq+MrKgbxTkSGzqpyeGFm461hG0v8tn+up6zaAqDSxKScj5+RccpxtqRl8xOf5jbBXlZCteITaD5X0owXRRLaxMsX07/S3CtHy5CyGvf5IRcAzuugX06SqYuXghE6cy1cNfvVyM9OAiqKKdlvNjDhuOA=="), session_token: None }, extra_headers: {}, extra_query: {}, path_style: false }
putting mj/ChainProvider.txt
putting mj/InstanceMetadataProvider.txt
delphix@ip-10-110-137-138:~/zfs/cmd/zfs_object_agent$ 
```