### PR TITLE
zpool properties

### DIFF
--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -88,6 +88,7 @@ COMMON_H = \
 	vdev_indirect_births.h \
 	vdev_indirect_mapping.h \
 	vdev_initialize.h \
+	vdev_object_store.h \
 	vdev_raidz.h \
 	vdev_raidz_impl.h \
 	vdev_rebuild.h \

--- a/include/sys/vdev_impl.h
+++ b/include/sys/vdev_impl.h
@@ -609,12 +609,6 @@ extern vdev_ops_t vdev_spare_ops;
 extern vdev_ops_t vdev_indirect_ops;
 extern vdev_ops_t vdev_object_store_ops;
 
-void object_store_begin_txg(vdev_t *, uint64_t);
-void object_store_end_txg(vdev_t *, nvlist_t *, uint64_t);
-void object_store_free_block(vdev_t *, uint64_t, uint64_t);
-void object_store_flush_writes(spa_t *);
-void object_store_restart_agent(vdev_t *vd);
-
 /*
  * Common size functions
  */

--- a/include/sys/vdev_object_store.h
+++ b/include/sys/vdev_object_store.h
@@ -1,0 +1,34 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2021 by Delphix. All rights reserved.
+ */
+
+#include <sys/zfs_context.h>
+
+typedef struct vdev_object_store_stats {
+	uint64_t voss_blocks_count;
+	uint64_t voss_blocks_bytes;
+	uint64_t voss_pending_frees_count;
+	uint64_t voss_pending_frees_bytes;
+	uint64_t voss_objects_count;
+} vdev_object_store_stats_t;
+
+void object_store_begin_txg(vdev_t *, uint64_t);
+void object_store_end_txg(vdev_t *, nvlist_t *, uint64_t);
+void object_store_free_block(vdev_t *, uint64_t, uint64_t);
+void object_store_flush_writes(spa_t *);
+void object_store_restart_agent(vdev_t *vd);
+void object_store_get_stats(vdev_t *, vdev_object_store_stats_t *);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -33,6 +33,7 @@
 #include <sys/metaslab_impl.h>
 #include <sys/vdev_impl.h>
 #include <sys/vdev_draid.h>
+#include <sys/vdev_object_store.h>
 #include <sys/zio.h>
 #include <sys/spa_impl.h>
 #include <sys/zfeature.h>

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -143,6 +143,7 @@
 #include <sys/vdev.h>
 #include <sys/vdev_impl.h>
 #include <sys/vdev_draid.h>
+#include <sys/vdev_object_store.h>
 #include <sys/uberblock_impl.h>
 #include <sys/metaslab.h>
 #include <sys/metaslab_impl.h>

--- a/module/zfs/zio.c
+++ b/module/zfs/zio.c
@@ -36,6 +36,7 @@
 #include <sys/spa_impl.h>
 #include <sys/vdev_impl.h>
 #include <sys/vdev_trim.h>
+#include <sys/vdev_object_store.h>
 #include <sys/zio_impl.h>
 #include <sys/zio_compress.h>
 #include <sys/zio_checksum.h>

--- a/module/zfs/zio_inject.c
+++ b/module/zfs/zio_inject.c
@@ -45,6 +45,7 @@
 #include <sys/zio.h>
 #include <sys/zfs_ioctl.h>
 #include <sys/vdev_impl.h>
+#include <sys/vdev_object_store.h>
 #include <sys/dmu_objset.h>
 #include <sys/dsl_dataset.h>
 #include <sys/metaslab_impl.h>


### PR DESCRIPTION
Add support for zpool `allocated` and `freeing` properties.

Rather than an explicit "get props" command to the agent, I return the stats each TXG, as part of the "txg end done" response.  So this will only update once per txg, but I think that should be fine.

Let me know if there are other existing properties that should have a meaning for object store.  (Suggestions of new properties also welcome but I wanted to hook up existing ones first.)

```
root@mahrens-agent:~# zpool list -v test
NAME                  SIZE  ALLOC   FREE  CKPOINT  EXPANDSZ   FRAG    CAP  DEDUP    HEALTH  ALTROOT
test                  512P  34.5G   512P        -         -     0%     0%  1.00x    ONLINE  -
  cloudburst-data-2   512P  34.5G   512P        -         -     0%  0.00%      -    ONLINE
root@mahrens-agent:~# zpool get freeing test
NAME  PROPERTY  VALUE    SOURCE
test  freeing   2.67G    -
```