### PR TITLE
async move

### DIFF
--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -2,7 +2,6 @@ use crate::pool::PoolSharedState;
 use crate::{base_types::*, object_access::ObjectAccess};
 use anyhow::{Context, Result};
 use async_stream::stream;
-use futures::future;
 use futures::future::join_all;
 use futures::stream::{FuturesOrdered, StreamExt};
 use futures_core::Stream;
@@ -235,37 +234,6 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         self.num_entries = 0;
     }
 
-    pub async fn read(&self) -> Vec<T> {
-        let mut stream = FuturesOrdered::new();
-        for chunk in 0..self.num_chunks {
-            let fut = ObjectBasedLogChunk::get(
-                &self.shared_state.object_access,
-                &self.name,
-                self.generation,
-                chunk,
-            );
-            stream.push(fut);
-        }
-        let mut entries = Vec::new();
-        // XXX may need to use stream.buffered() so we don't have too many outstanding fd's / connections
-        // XXX or retire this in favor of the iterate() interface
-        stream
-            .for_each(|res| {
-                let mut chunk = res.unwrap();
-                debug!(
-                    "appending {} entries of chunk {}",
-                    chunk.entries.len(),
-                    chunk.chunk
-                );
-                entries.append(&mut chunk.entries);
-                future::ready(())
-            })
-            .await;
-
-        debug!("got {} entries total", entries.len());
-        entries
-    }
-
     /// Iterates the on-disk state; panics if there are pending changes.
     pub fn iterate(&self) -> impl Stream<Item = T> {
         assert_eq!(self.num_flushed_chunks, self.num_chunks);
@@ -291,11 +259,11 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
             let shared_state = self.shared_state.clone();
             let n = self.name.clone();
             stream.push(async move {
-                future::ready(
+                async move {
                     ObjectBasedLogChunk::get(&shared_state.object_access, &n, generation, chunk)
                         .await
-                        .unwrap(),
-                )
+                        .unwrap()
+                }
             });
         }
         // Note: buffered() is needed because rust-s3 creates one connection for

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -630,11 +630,9 @@ impl Pool {
                 let sub_stream = FuturesUnordered::new();
                 for key in vec {
                     let shared_state = shared_state.clone();
-                    sub_stream.push(async move {
-                        async move {
-                            DataObjectPhys::get_from_key(&shared_state.object_access, &key).await
-                        }
-                    });
+                    sub_stream.push(future::ready(async move {
+                        DataObjectPhys::get_from_key(&shared_state.object_access, &key).await
+                    }));
                 }
                 sub_stream
             })
@@ -1364,7 +1362,7 @@ async fn reclaim_frees_object(
         let min_block = state.object_block_map.object_to_min_block(object);
         let next_block = state.object_block_map.object_to_next_block(object);
         let my_shared_state = shared_state.clone();
-        stream.push(async move {
+        stream.push(future::ready(async move {
             let mut phys =
                 DataObjectPhys::get(&my_shared_state.object_access, my_shared_state.guid, object)
                     .await
@@ -1429,8 +1427,8 @@ async fn reclaim_frees_object(
                 assert_eq!(phys.blocks_size, new_object_size);
             }
 
-            future::ready(phys)
-        });
+            phys
+        }));
     }
     let new_phys = stream
         .buffered(10)

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -631,9 +631,9 @@ impl Pool {
                 for key in vec {
                     let shared_state = shared_state.clone();
                     sub_stream.push(async move {
-                        future::ready(
-                            DataObjectPhys::get_from_key(&shared_state.object_access, &key).await,
-                        )
+                        async move {
+                            DataObjectPhys::get_from_key(&shared_state.object_access, &key).await
+                        }
                     });
                 }
                 sub_stream


### PR DESCRIPTION
When running a workload of writing/freeing to the object store pool, @don-brady noticed a lot of messages like this in the agent's log:

`[2021-07-01 03:06:50.156][::object_access][DEBUG] get zfs/11689269492085668192/PendingFreesLog/00000000000000000022/00000000000000002364 returned: HttpDispatch(HttpDispatchError { message: "Error during dispatch: error trying to connect: tcp open error: Too many open files (os error 24)" }); retrying in 80ms`

Turns out that the changes in https://github.com/delphix/zfs/pull/350 accidentally changed the behavior such that buffered streams were no longer effectively buffered.  This is especially impactful in `ObjectBasedLog::iter_impl()`.