### PR TITLE
fix bug in ObjectBlockMap::object_to_next_block

### DIFF
--- a/cmd/zfs_object_agent/src/object_block_map.rs
+++ b/cmd/zfs_object_agent/src/object_block_map.rs
@@ -1,13 +1,40 @@
 use crate::base_types::*;
+use crate::object_based_log::ObjectBasedLog;
+use crate::object_based_log::ObjectBasedLogEntry;
+use futures::future;
+use futures::StreamExt;
+use log::*;
 use more_asserts::*;
+use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::ops::Bound::*;
 use std::sync::RwLock;
+use std::time::Instant;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+// XXX make this private and make methods for everything that uses it
+pub enum StorageObjectLogEntry {
+    Alloc {
+        object: ObjectID,
+        min_block: BlockID,
+    },
+    Free {
+        object: ObjectID,
+    },
+}
+impl OnDisk for StorageObjectLogEntry {}
+impl ObjectBasedLogEntry for StorageObjectLogEntry {}
+
+#[derive(Debug)]
 pub struct ObjectBlockMap {
-    map: RwLock<BTreeSet<ObjectBlockMapEntry>>,
+    state: RwLock<ObjectBlockMapState>,
+}
+
+#[derive(Debug)]
+struct ObjectBlockMapState {
+    map: BTreeSet<ObjectBlockMapEntry>,
+    next_block: BlockID,
 }
 
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq, Copy, Clone)]
@@ -29,47 +56,109 @@ impl Borrow<BlockID> for ObjectBlockMapEntry {
 }
 
 impl ObjectBlockMap {
-    pub fn new() -> Self {
-        ObjectBlockMap::default()
-    }
+    pub async fn load(
+        storage_object_log: &ObjectBasedLog<StorageObjectLogEntry>,
+        next_block: BlockID,
+    ) -> Self {
+        let begin = Instant::now();
+        let mut num_alloc_entries: u64 = 0;
+        let mut num_free_entries: u64 = 0;
+        let mut map: BTreeSet<ObjectBlockMapEntry> = BTreeSet::new();
+        storage_object_log
+            .iterate()
+            .for_each(|ent| {
+                match ent {
+                    StorageObjectLogEntry::Alloc {
+                        object,
+                        min_block: first_possible_block,
+                    } => {
+                        Self::insert_setup(&mut map, object, first_possible_block);
+                        num_alloc_entries += 1;
+                    }
+                    StorageObjectLogEntry::Free { object } => {
+                        let removed = map.remove(&object);
+                        assert!(removed);
+                        num_free_entries += 1;
+                    }
+                }
 
-    pub fn verify(&self) {
+                future::ready(())
+            })
+            .await;
+        info!(
+            "loaded mapping from {} objects with {} allocs and {} frees in {}ms",
+            storage_object_log.num_chunks,
+            num_alloc_entries,
+            num_free_entries,
+            begin.elapsed().as_millis()
+        );
+
         let mut prev_ent_opt: Option<ObjectBlockMapEntry> = None;
-        for ent in self.map.read().unwrap().iter() {
+        for ent in map.iter() {
             if let Some(prev_ent) = prev_ent_opt {
                 assert_gt!(ent.object, prev_ent.object);
                 assert_gt!(ent.block, prev_ent.block);
             }
             prev_ent_opt = Some(*ent);
         }
+        ObjectBlockMap {
+            state: RwLock::new(ObjectBlockMapState { map, next_block }),
+        }
     }
 
-    pub fn insert(&self, object: ObjectID, block: BlockID) {
+    // during setup (i.e. before done_setting_up() is called), we can insert in
+    // any order, and without specifying the next_block
+    pub fn insert_setup(
+        map: &mut BTreeSet<ObjectBlockMapEntry>,
+        object: ObjectID,
+        first_block: BlockID,
+    ) {
         // verify that this block is between the existing entries blocks
-        let mut map = self.map.write().unwrap();
         let prev_ent_opt = map.range((Unbounded, Excluded(object))).next_back();
         if let Some(prev_ent) = prev_ent_opt {
-            assert_lt!(prev_ent.block, block);
+            assert_lt!(prev_ent.block, first_block);
         }
         let next_ent_opt = map.range((Excluded(object), Unbounded)).next();
         if let Some(next_ent) = next_ent_opt {
-            assert_gt!(next_ent.block, block);
+            assert_gt!(next_ent.block, first_block);
         }
         // verify that this object is not yet in the map
         assert!(!map.contains(&object));
 
-        map.insert(ObjectBlockMapEntry { object, block });
+        map.insert(ObjectBlockMapEntry {
+            object,
+            block: first_block,
+        });
+    }
+
+    pub fn insert(&self, object: ObjectID, first_block: BlockID, next_block: BlockID) {
+        // verify that this object and block are after the last
+        let mut state = self.state.write().unwrap();
+        assert_lt!(first_block, next_block);
+        assert_eq!(first_block, state.next_block);
+        if let Some(last_ent) = state.map.iter().next_back() {
+            assert_gt!(object, last_ent.object);
+            assert_gt!(first_block, last_ent.block);
+        }
+
+        state.map.insert(ObjectBlockMapEntry {
+            object,
+            block: first_block,
+        });
+
+        state.next_block = next_block;
     }
 
     pub fn remove(&self, object: ObjectID) {
-        let removed = self.map.write().unwrap().remove(&object);
+        let mut state = self.state.write().unwrap();
+        let removed = state.map.remove(&object);
         assert!(removed);
     }
 
     pub fn block_to_object(&self, block: BlockID) -> ObjectID {
-        self.map
-            .read()
-            .unwrap()
+        let state = self.state.read().unwrap();
+        state
+            .map
             .range((Unbounded, Included(block)))
             .next_back()
             .unwrap()
@@ -77,23 +166,26 @@ impl ObjectBlockMap {
     }
 
     pub fn object_to_min_block(&self, object: ObjectID) -> BlockID {
-        self.map.read().unwrap().get(&object).unwrap().block
+        let state = self.state.read().unwrap();
+        state.map.get(&object).unwrap().block
     }
 
     pub fn object_to_next_block(&self, object: ObjectID) -> BlockID {
-        self.map
-            .read()
-            .unwrap()
-            .range((Excluded(object), Unbounded))
-            .next()
-            .unwrap()
-            .block
+        let state = self.state.read().unwrap();
+
+        // The "next block" (i.e. the first BlockID that's not valid in this
+        // object) is the next object's first block.  Or if this is the last
+        // object, it's the next block of the entire pool (state.next_block).
+        match state.map.range((Excluded(object), Unbounded)).next() {
+            Some(entry) => entry.block,
+            None => state.next_block,
+        }
     }
 
     pub fn last_object(&self) -> ObjectID {
-        self.map
-            .read()
-            .unwrap()
+        let state = self.state.read().unwrap();
+        state
+            .map
             .iter()
             .next_back()
             .unwrap_or(&ObjectBlockMapEntry {
@@ -104,14 +196,16 @@ impl ObjectBlockMap {
     }
 
     pub fn len(&self) -> usize {
-        self.map.read().unwrap().len()
+        let state = self.state.read().unwrap();
+        state.map.len()
     }
 
     pub fn for_each<CB>(&self, mut f: CB)
     where
         CB: FnMut(&ObjectBlockMapEntry),
     {
-        for ent in self.map.read().unwrap().iter() {
+        let state = self.state.read().unwrap();
+        for ent in state.map.iter() {
             f(ent);
         }
     }

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -2,6 +2,7 @@ use crate::base_types::*;
 use crate::object_access::ObjectAccess;
 use crate::object_based_log::*;
 use crate::object_block_map::ObjectBlockMap;
+use crate::object_block_map::StorageObjectLogEntry;
 use crate::zettacache::ZettaCache;
 use anyhow::{Context, Result};
 use core::future::Future;
@@ -96,19 +97,6 @@ struct DataObjectPhys {
     blocks: HashMap<BlockID, ByteBuf>,
 }
 impl OnDisk for DataObjectPhys {}
-
-#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
-enum StorageObjectLogEntry {
-    Alloc {
-        object: ObjectID,
-        min_block: BlockID,
-    },
-    Free {
-        object: ObjectID,
-    },
-}
-impl OnDisk for StorageObjectLogEntry {}
-impl ObjectBasedLogEntry for StorageObjectLogEntry {}
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone)]
 enum ObjectSizeLogEntry {
@@ -292,6 +280,7 @@ struct PoolSyncingState {
     // Note: some objects may contain additional (adjacent) blocks, if they have
     // been consolidated but this fact is not yet represented in the log.  A
     // consolidated object won't be removed until after the log reflects that.
+    // XXX put this in its own type (in object_block_map.rs?)
     storage_object_log: ObjectBasedLog<StorageObjectLogEntry>,
 
     // Note: the object_size_log may not have the most up-to-date size info for
@@ -447,17 +436,22 @@ impl Pool {
             guid: pool_phys.guid,
             name: pool_phys.name.clone(),
         });
+
+        // load block -> object mapping
+        let storage_object_log = ObjectBasedLog::open_by_phys(
+            shared_state.clone(),
+            &format!("zfs/{}/StorageObjectLog", pool_phys.guid),
+            &phys.storage_object_log,
+        );
+        let object_block_map = ObjectBlockMap::load(&storage_object_log, phys.next_block).await;
+
         let pool = Pool {
             state: Arc::new(PoolState {
                 shared_state: shared_state.clone(),
                 syncing_state: std::sync::Mutex::new(Some(PoolSyncingState {
                     last_txg: phys.txg,
                     syncing_txg: None,
-                    storage_object_log: ObjectBasedLog::open_by_phys(
-                        shared_state.clone(),
-                        &format!("zfs/{}/StorageObjectLog", pool_phys.guid),
-                        &phys.storage_object_log,
-                    ),
+                    storage_object_log,
                     object_size_log: ObjectBasedLog::open_by_phys(
                         shared_state.clone(),
                         &format!("zfs/{}/ObjectSizeLog", pool_phys.guid),
@@ -477,7 +471,7 @@ impl Pool {
                     pending_flushes: BTreeSet::new(),
                 })),
                 zettacache: cache,
-                object_block_map: ObjectBlockMap::new(),
+                object_block_map,
             }),
         };
 
@@ -489,43 +483,6 @@ impl Pool {
         syncing_state.storage_object_log.recover().await;
         syncing_state.object_size_log.recover().await;
         syncing_state.pending_frees_log.recover().await;
-
-        // load block -> object mapping
-        let begin = Instant::now();
-        let mut num_alloc_entries: u64 = 0;
-        let mut num_free_entries: u64 = 0;
-        syncing_state
-            .storage_object_log
-            .iterate()
-            .for_each(|ent| {
-                match ent {
-                    StorageObjectLogEntry::Alloc {
-                        object,
-                        min_block: first_possible_block,
-                    } => {
-                        pool.state
-                            .object_block_map
-                            .insert(object, first_possible_block);
-                        num_alloc_entries += 1;
-                    }
-                    StorageObjectLogEntry::Free { object } => {
-                        pool.state.object_block_map.remove(object);
-                        num_free_entries += 1;
-                    }
-                }
-
-                future::ready(())
-            })
-            .await;
-        info!(
-            "loaded mapping from {} objects with {} allocs and {} frees in {}ms",
-            syncing_state.storage_object_log.num_chunks,
-            num_alloc_entries,
-            num_free_entries,
-            begin.elapsed().as_millis()
-        );
-
-        pool.state.object_block_map.verify();
 
         assert_eq!(
             pool.state.object_block_map.len() as u64,
@@ -552,16 +509,20 @@ impl Pool {
                 guid,
                 name: phys.name,
             });
+
+            let storage_object_log = ObjectBasedLog::create(
+                shared_state.clone(),
+                &format!("zfs/{}/StorageObjectLog", guid),
+            );
+            let object_block_map = ObjectBlockMap::load(&storage_object_log, BlockID(0)).await;
+
             let pool = Pool {
                 state: Arc::new(PoolState {
                     shared_state: shared_state.clone(),
                     syncing_state: std::sync::Mutex::new(Some(PoolSyncingState {
                         last_txg: TXG(0),
                         syncing_txg: None,
-                        storage_object_log: ObjectBasedLog::create(
-                            shared_state.clone(),
-                            &format!("zfs/{}/StorageObjectLog", guid),
-                        ),
+                        storage_object_log,
                         object_size_log: ObjectBasedLog::create(
                             shared_state.clone(),
                             &format!("zfs/{}/ObjectSizeLog", guid),
@@ -579,7 +540,7 @@ impl Pool {
                         pending_flushes: BTreeSet::new(),
                     })),
                     zettacache: cache,
-                    object_block_map: ObjectBlockMap::new(),
+                    object_block_map,
                 }),
             };
 
@@ -962,11 +923,13 @@ impl Pool {
         assert_eq!(phys.guid, state.shared_state.guid);
         assert_eq!(phys.min_txg, txg);
         assert_eq!(phys.max_txg, txg);
-        assert_ge!(object, state.object_block_map.last_object().next());
+        assert_gt!(object, state.object_block_map.last_object());
         syncing_state.stats.objects_count += 1;
         syncing_state.stats.blocks_bytes += phys.blocks_size as u64;
         syncing_state.stats.blocks_count += phys.blocks.len() as u64;
-        state.object_block_map.insert(object, phys.min_block);
+        state
+            .object_block_map
+            .insert(object, phys.min_block, phys.next_block);
         syncing_state.storage_object_log.append(
             txg,
             StorageObjectLogEntry::Alloc {


### PR DESCRIPTION
@don-brady hit a bug where the `unwrap()` in  `ObjectBlockMap::object_to_next_block()` failed.  The problem occurs when we call this function on the last object in the pool.  In this case we try to find its "next block" by getting the "first block" of the next object.  However, since this is the last object, there is no "next object".

The solution is for the ObjectBlockMap to keep track of the pool-wide "next block", which is the "next block" of the last object.  While implementing this, we realized that the code could be cleaned up by having ObjectBlockMap encapsulate more of the functionality related to the on-disk representation (the `ObjectBasedLog<StorageObjectLogEntry>`).  More cleanup of this interface is forthcoming.