### PR TITLE
clean up zettacache interfaces

### DIFF
--- a/cmd/zfs_object_agent/src/block_allocator.rs
+++ b/cmd/zfs_object_agent/src/block_allocator.rs
@@ -61,10 +61,8 @@ impl BlockAllocator {
         }
         self.allocating.clear();
 
-        self.space_map.flush().await;
-
         BlockAllocatorPhys {
-            allocatable: self.space_map.get_phys(),
+            allocatable: self.space_map.flush().await,
         }
     }
 

--- a/cmd/zfs_object_agent/src/index.rs
+++ b/cmd/zfs_object_agent/src/index.rs
@@ -1,0 +1,73 @@
+use crate::base_types::*;
+use crate::block_access::*;
+use crate::block_based_log::*;
+use crate::extent_allocator::ExtentAllocator;
+use crate::zettacache::AtimeHistogramPhys;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
+pub struct IndexKey {
+    pub guid: PoolGUID,
+    pub block: BlockID,
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
+pub struct IndexValue {
+    pub location: DiskLocation,
+    // XXX remove this and figure out based on which slab it's in?  However,
+    // currently we need to return the right buffer size to the kernel, and it
+    // isn't passing us the expected read size.  So we need to change some
+    // interfaces to make that work right.
+    pub size: usize,
+    pub atime: Atime,
+}
+
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+pub struct IndexEntry {
+    pub key: IndexKey,
+    pub value: IndexValue,
+}
+impl OnDisk for IndexEntry {}
+impl BlockBasedLogEntry for IndexEntry {}
+
+pub struct ZettaCacheIndex {
+    pub atime_histogram: AtimeHistogramPhys,
+    pub log: BlockBasedLogWithSummary<IndexEntry>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct ZettaCacheIndexPhys {
+    atime_histogram: AtimeHistogramPhys,
+    log: BlockBasedLogWithSummaryPhys,
+}
+
+impl ZettaCacheIndex {
+    pub async fn open(
+        block_access: Arc<BlockAccess>,
+        extent_allocator: Arc<ExtentAllocator>,
+        phys: ZettaCacheIndexPhys,
+    ) -> Self {
+        Self {
+            atime_histogram: phys.atime_histogram,
+            log: BlockBasedLogWithSummary::open(block_access, extent_allocator, phys.log).await,
+        }
+    }
+
+    pub async fn flush(&mut self) -> ZettaCacheIndexPhys {
+        ZettaCacheIndexPhys {
+            atime_histogram: self.atime_histogram.clone(),
+            log: self.log.flush().await,
+        }
+    }
+
+    pub fn append(&mut self, entry: IndexEntry) {
+        self.atime_histogram.insert(entry.value.atime);
+        self.log.append(entry);
+    }
+
+    pub fn clear(&mut self) {
+        self.atime_histogram.clear();
+        self.log.clear();
+    }
+}

--- a/cmd/zfs_object_agent/src/lib.rs
+++ b/cmd/zfs_object_agent/src/lib.rs
@@ -3,6 +3,7 @@ pub mod block_access;
 pub mod block_allocator;
 pub mod block_based_log;
 pub mod extent_allocator;
+pub mod index;
 pub mod object_access;
 pub mod object_based_log;
 pub mod object_block_map;

--- a/cmd/zfs_object_agent/src/space_map.rs
+++ b/cmd/zfs_object_agent/src/space_map.rs
@@ -86,13 +86,9 @@ impl SpaceMap {
             .append(SpaceMapEntry::Free(SpaceMapExtent { offset, size }));
     }
 
-    pub async fn flush(&mut self) {
-        self.log.flush().await;
-    }
-
-    pub fn get_phys(&self) -> SpaceMapPhys {
+    pub async fn flush(&mut self) -> SpaceMapPhys {
         SpaceMapPhys {
-            log: self.log.get_phys(),
+            log: self.log.flush().await,
             coverage: self.coverage,
         }
     }


### PR DESCRIPTION
Based on discussion with @sdimitro, made some changes to the interfaces within the zettacache:

- combine `.get_phys()` and `.flush()` calls into one API (`.flush()` which returns the new "phys")
- move "index" data structures to their own file

Note: the idea of combining .get_phys() into .flush() applies to the object management part of the agent as well.  It's a little more complicated to do there but I'll work on that next.

I'm also considering making the .flush() API a Rust `trait`, which would let us enforce some things about that interface but it makes the code slightly harder to navigate, so I'm putting that off until I find a more clear benefit (e.g. we want to be able to "register" a bunch of "flushable" objects and then call all of them with a `for` loop, rather than the current hard-coding of what objects to .flush().)