### PR TITLE
Make cargo clippy clean

### DIFF
--- a/cmd/zfs_object_agent/client/src/client.rs
+++ b/cmd/zfs_object_agent/client/src/client.rs
@@ -73,7 +73,7 @@ impl Client {
         region: &str,
         endpoint: &str,
         bucket_name: &str,
-        guid: PoolGUID,
+        guid: PoolGuid,
         name: &str,
     ) {
         let mut nvl = NvList::new_unique_names();
@@ -97,7 +97,7 @@ impl Client {
         region: &str,
         endpoint: &str,
         bucket_name: &str,
-        guid: PoolGUID,
+        guid: PoolGuid,
     ) {
         let mut nvl = NvList::new_unique_names();
         let credentials = Self::get_credential_string(aws_key_id, secret_key);
@@ -111,7 +111,7 @@ impl Client {
         self.send_request(nvl.as_ref()).await;
     }
 
-    pub async fn read_block(&mut self, guid: PoolGUID, block: BlockID) {
+    pub async fn read_block(&mut self, guid: PoolGuid, block: BlockId) {
         let mut nvl = NvList::new_unique_names();
         nvl.insert("Type", "read block").unwrap();
         nvl.insert("GUID", &guid.0).unwrap();
@@ -120,7 +120,7 @@ impl Client {
         self.send_request(nvl.as_ref()).await;
     }
 
-    pub async fn write_block(&mut self, guid: PoolGUID, block: BlockID, data: &[u8]) {
+    pub async fn write_block(&mut self, guid: PoolGuid, block: BlockId, data: &[u8]) {
         let mut nvl = NvList::new_unique_names();
         nvl.insert("Type", "write block").unwrap();
         nvl.insert("GUID", &guid.0).unwrap();
@@ -129,7 +129,7 @@ impl Client {
         self.send_request(nvl.as_ref()).await;
     }
 
-    pub async fn free_block(&mut self, guid: PoolGUID, block: BlockID) {
+    pub async fn free_block(&mut self, guid: PoolGuid, block: BlockId) {
         let mut nvl = NvList::new_unique_names();
         nvl.insert("Type", "free block").unwrap();
         nvl.insert("GUID", &guid.0).unwrap();
@@ -137,7 +137,7 @@ impl Client {
         self.send_request(nvl.as_ref()).await;
     }
 
-    pub async fn begin_txg(&mut self, guid: PoolGUID, txg: TXG) {
+    pub async fn begin_txg(&mut self, guid: PoolGuid, txg: Txg) {
         let mut nvl = NvList::new_unique_names();
         nvl.insert("Type", "begin txg").unwrap();
         nvl.insert("GUID", &guid.0).unwrap();
@@ -145,7 +145,7 @@ impl Client {
         self.send_request(nvl.as_ref()).await;
     }
 
-    pub async fn end_txg(&mut self, guid: PoolGUID, uberblock: &[u8]) {
+    pub async fn end_txg(&mut self, guid: PoolGuid, uberblock: &[u8]) {
         let mut nvl = NvList::new_unique_names();
         nvl.insert("Type", "end txg").unwrap();
         nvl.insert("GUID", &guid.0).unwrap();
@@ -153,7 +153,7 @@ impl Client {
         self.send_request(nvl.as_ref()).await;
     }
 
-    pub async fn flush_writes(&mut self, guid: PoolGUID) {
+    pub async fn flush_writes(&mut self, guid: PoolGuid) {
         let mut nvl = NvList::new_unique_names();
         nvl.insert("Type", "flush writes").unwrap();
         nvl.insert("GUID", &guid.0).unwrap();

--- a/cmd/zfs_object_agent/src/base_types.rs
+++ b/cmd/zfs_object_agent/src/base_types.rs
@@ -10,48 +10,48 @@ use std::ops::Add;
 pub trait OnDisk: Serialize + DeserializeOwned {}
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
-pub struct TXG(pub u64);
-impl OnDisk for TXG {}
-impl Display for TXG {
+pub struct Txg(pub u64);
+impl OnDisk for Txg {}
+impl Display for Txg {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{:020}", self.0)
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct PoolGUID(pub u64);
-impl OnDisk for PoolGUID {}
-impl Display for PoolGUID {
+pub struct PoolGuid(pub u64);
+impl OnDisk for PoolGuid {}
+impl Display for PoolGuid {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{:020}", self.0)
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct ObjectID(pub u64);
-impl OnDisk for ObjectID {}
-impl Display for ObjectID {
+pub struct ObjectId(pub u64);
+impl OnDisk for ObjectId {}
+impl Display for ObjectId {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{:020}", self.0)
     }
 }
-impl ObjectID {
-    pub fn next(&self) -> ObjectID {
-        ObjectID(self.0 + 1)
+impl ObjectId {
+    pub fn next(&self) -> ObjectId {
+        ObjectId(self.0 + 1)
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
-pub struct BlockID(pub u64);
-impl OnDisk for BlockID {}
-impl Display for BlockID {
+pub struct BlockId(pub u64);
+impl OnDisk for BlockId {}
+impl Display for BlockId {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{}", self.0)
     }
 }
-impl BlockID {
-    pub fn next(&self) -> BlockID {
-        BlockID(self.0 + 1)
+impl BlockId {
+    pub fn next(&self) -> BlockId {
+        BlockId(self.0 + 1)
     }
 }
 
@@ -95,10 +95,10 @@ impl Extent {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
-pub struct CheckpointID(pub u64);
-impl CheckpointID {
-    pub fn next(&self) -> CheckpointID {
-        CheckpointID(self.0 + 1)
+pub struct CheckpointId(pub u64);
+impl CheckpointId {
+    pub fn next(&self) -> CheckpointId {
+        CheckpointId(self.0 + 1)
     }
 }
 

--- a/cmd/zfs_object_agent/src/index.rs
+++ b/cmd/zfs_object_agent/src/index.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct IndexKey {
-    pub guid: PoolGUID,
-    pub block: BlockID,
+    pub guid: PoolGuid,
+    pub block: BlockId,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]

--- a/cmd/zfs_object_agent/src/object_access.rs
+++ b/cmd/zfs_object_agent/src/object_access.rs
@@ -49,6 +49,7 @@ pub fn prefixed(key: &str) -> String {
 }
 
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 enum OAError<E>
 where
     E: core::fmt::Debug + core::fmt::Display + std::error::Error,
@@ -117,11 +118,9 @@ where
     let result = match timeout_opt {
         Some(timeout) => match tokio::time::timeout(timeout, retry_impl(msg, f)).await {
             Err(e) => Err(OAError::TimeoutError(e)),
-            Ok(res2) => res2.map_err(|e| OAError::RequestError(e)),
+            Ok(res2) => res2.map_err(OAError::RequestError),
         },
-        None => retry_impl(msg, f)
-            .await
-            .map_err(|e| OAError::RequestError(e)),
+        None => retry_impl(msg, f).await.map_err(OAError::RequestError),
     };
     let elapsed = begin.elapsed();
     debug!("{}: returned in {}ms", msg, elapsed.as_millis());

--- a/cmd/zfs_object_agent/src/object_based_log.rs
+++ b/cmd/zfs_object_agent/src/object_based_log.rs
@@ -32,10 +32,10 @@ pub struct ObjectBasedLogPhys {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ObjectBasedLogChunk<T: ObjectBasedLogEntry> {
-    guid: PoolGUID,
+    guid: PoolGuid,
     generation: u64,
     chunk: u64,
-    txg: TXG,
+    txg: Txg,
     #[serde(bound(deserialize = "Vec<T>: DeserializeOwned"))]
     entries: Vec<T>,
 }
@@ -180,7 +180,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         }
     }
 
-    pub fn append(&mut self, txg: TXG, entry: T) {
+    pub fn append(&mut self, txg: Txg, entry: T) {
         assert!(self.recovered);
         // XXX assert that txg is the same as the txg for the other pending entries?
         self.pending_entries.push(entry);
@@ -190,7 +190,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         }
     }
 
-    pub fn initiate_flush(&mut self, txg: TXG) {
+    pub fn initiate_flush(&mut self, txg: Txg) {
         assert!(self.recovered);
 
         let chunk = ObjectBasedLogChunk {
@@ -216,7 +216,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         assert!(self.pending_entries.is_empty());
     }
 
-    pub async fn flush(&mut self, txg: TXG) {
+    pub async fn flush(&mut self, txg: Txg) {
         if !self.pending_entries.is_empty() {
             self.initiate_flush(txg);
         }
@@ -228,7 +228,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
         self.num_flushed_chunks = self.num_chunks;
     }
 
-    pub async fn clear(&mut self, txg: TXG) {
+    pub async fn clear(&mut self, txg: Txg) {
         self.flush(txg).await;
         self.generation += 1;
         self.num_chunks = 0;
@@ -295,7 +295,7 @@ impl<T: ObjectBasedLogEntry> ObjectBasedLog<T> {
     /// (async) for any pending changes to be flushed.
     pub async fn iter_remainder(
         &mut self,
-        txg: TXG,
+        txg: Txg,
         first_chunk: ObjectBasedLogRemainder,
     ) -> impl Stream<Item = T> {
         self.flush(txg).await;

--- a/cmd/zfs_object_agent/src/space_map.rs
+++ b/cmd/zfs_object_agent/src/space_map.rs
@@ -53,7 +53,7 @@ impl SpaceMap {
         phys: SpaceMapPhys,
     ) -> SpaceMap {
         SpaceMap {
-            log: BlockBasedLog::open(block_access.clone(), extent_allocator.clone(), phys.log),
+            log: BlockBasedLog::open(block_access, extent_allocator, phys.log),
             coverage: phys.coverage,
         }
     }


### PR DESCRIPTION
This PR fixes all the issues reported by `cargo clippy`, which is the rust linter. Most of the changes are to comply with the Rust naming conventions (acronyms and initialisms should only capitalize the first letter), though one is left as is with the lint warning disabled for comparison. If people prefer that approach, the others can be changed to do the same.  The contentful changes are to remove some redundant clones, removing a closure by using the function as a first-class entity, and changing the Mutex<usize> for the outstanding write count to an AtomicUsize. 