### PR TITLE
Remove object-credentials-location parameter

### DIFF
--- a/cmd/zfs_object_agent/client/src/client.rs
+++ b/cmd/zfs_object_agent/client/src/client.rs
@@ -62,13 +62,8 @@ impl Client {
         self.output.write_all(buf.as_ref()).await.unwrap();
     }
 
-    pub fn get_credential_string(aws_key_id: &str, secret_key: &str) -> String {
-        format!("{}:{}", aws_key_id, secret_key)
-    }
-
     pub async fn create_pool(
         &mut self,
-        credentials: String,
         region: &str,
         endpoint: &str,
         bucket_name: &str,
@@ -78,7 +73,6 @@ impl Client {
         let mut nvl = NvList::new_unique_names();
 
         nvl.insert("Type", "create pool").unwrap();
-        nvl.insert("credentials", credentials.as_str()).unwrap();
         nvl.insert("region", region).unwrap();
         nvl.insert("endpoint", endpoint).unwrap();
         nvl.insert("bucket", bucket_name).unwrap();
@@ -90,18 +84,14 @@ impl Client {
 
     pub async fn open_pool(
         &mut self,
-        aws_key_id: &str,
-        secret_key: &str,
         region: &str,
         endpoint: &str,
         bucket_name: &str,
         guid: PoolGuid,
     ) {
         let mut nvl = NvList::new_unique_names();
-        let credentials = Self::get_credential_string(aws_key_id, secret_key);
 
         nvl.insert("Type", "open pool").unwrap();
-        nvl.insert("credentials", credentials.as_str()).unwrap();
         nvl.insert("region", region).unwrap();
         nvl.insert("endpoint", endpoint).unwrap();
         nvl.insert("bucket", bucket_name).unwrap();

--- a/cmd/zfs_object_agent/src/heartbeat.rs
+++ b/cmd/zfs_object_agent/src/heartbeat.rs
@@ -44,7 +44,7 @@ impl HeartbeatPhys {
         timeout: Option<Duration>,
     ) -> Result<
         rusoto_s3::PutObjectOutput,
-        OAError<rusoto_core::RusotoError<rusoto_s3::PutObjectError>>,
+        OAError<rusoto_s3::PutObjectError>,
     > {
         debug!("putting {:#?}", self);
         let buf = serde_json::to_vec(&self).unwrap();

--- a/cmd/zfs_object_agent/src/pool.rs
+++ b/cmd/zfs_object_agent/src/pool.rs
@@ -83,7 +83,7 @@ impl PoolOwnerPhys {
         timeout: Option<Duration>,
     ) -> Result<
         rusoto_s3::PutObjectOutput,
-        OAError<rusoto_core::RusotoError<rusoto_s3::PutObjectError>>,
+        OAError<rusoto_s3::PutObjectError>,
     > {
         debug!("putting {:#?}", self);
         let buf = serde_json::to_vec(&self).unwrap();

--- a/cmd/zfs_object_agent/src/server.rs
+++ b/cmd/zfs_object_agent/src/server.rs
@@ -251,10 +251,16 @@ impl Server {
         let region_str = nvl.lookup_string("region").unwrap();
         let endpoint = nvl.lookup_string("endpoint").unwrap();
         let readonly = nvl.lookup("readonly").is_ok();
+        let credentials_profile: Option<String> = nvl
+            .lookup_string("credentials_profile")
+            .ok()
+            .map(|s| s.to_str().unwrap().to_string());
+
         ObjectAccess::new(
             endpoint.to_str().unwrap(),
             region_str.to_str().unwrap(),
             bucket_name.to_str().unwrap(),
+            credentials_profile,
             readonly,
         )
     }
@@ -262,10 +268,18 @@ impl Server {
     async fn get_pools(&mut self, nvl: &NvList) {
         let region_cstr = nvl.lookup_string("region").unwrap();
         let endpoint_cstr = nvl.lookup_string("endpoint").unwrap();
-
         let region = region_cstr.to_str().unwrap();
         let endpoint = endpoint_cstr.to_str().unwrap();
-        let mut client = ObjectAccess::get_client(endpoint, region);
+        let credentials_profile: Option<String> = nvl
+            .lookup_string("credentials_profile")
+            .ok()
+            .map(|s| s.to_str().unwrap().to_owned());
+
+        let mut client = ObjectAccess::get_client(
+            endpoint,
+            region,
+            credentials_profile,
+        );
         let mut resp = NvList::new_unique_names();
         let mut buckets = vec![];
         if let Ok(bucket) = nvl.lookup_string("bucket") {

--- a/cmd/zpool/zpool_main.c
+++ b/cmd/zpool/zpool_main.c
@@ -1549,16 +1549,11 @@ zpool_do_create(int argc, char **argv)
 		goto errout;
 	}
 
-	char *credloc, *credentials;
+	char *profile;
 	if ((nvlist_lookup_string(props,
-	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS), &credloc)) == 0) {
-		if (zpool_get_objstore_credentials(g_zfs, credloc,
-		    &credentials) != 0) {
-			goto errout;
-		}
-		fnvlist_add_string(props, ZPOOL_CONFIG_OBJSTORE_CREDENTIALS,
-		    credentials);
-		free(credentials);
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CRED_PROFILE), &profile)) == 0) {
+		fnvlist_add_string(props, ZPOOL_CONFIG_CRED_PROFILE,
+		    profile);
 	}
 
 	/* pass off to make_root_vdev for bulk processing */
@@ -1568,10 +1563,10 @@ zpool_do_create(int argc, char **argv)
 		goto errout;
 
 	/*
-	 * We dont' store the creds as a normal property, so remove
+	 * We don't store the creds profile as a normal property, so remove
 	 * it now that is has been consumed.
 	 */
-	(void) nvlist_remove_all(props, ZPOOL_CONFIG_OBJSTORE_CREDENTIALS);
+	(void) nvlist_remove_all(props, ZPOOL_CONFIG_CRED_PROFILE);
 
 	/* make_root_vdev() allows 0 toplevel children if there are spares */
 	if (!zfs_allocatable_devs(nvroot)) {
@@ -3728,8 +3723,6 @@ zpool_do_import(int argc, char **argv)
 	idata.scan = do_scan;
 	idata.policy = policy;
 	idata.props = props;
-	idata.handle_creds =
-	    (int (*)(void *, char *, char **))zpool_get_objstore_credentials;
 
 	pools = zpool_search_import(g_zfs, &idata, &libzfs_config_ops);
 

--- a/cmd/zpool/zpool_vdev.c
+++ b/cmd/zpool/zpool_vdev.c
@@ -263,7 +263,7 @@ static nvlist_t *
 make_objstore_vdev(nvlist_t *props, const char *arg)
 {
 	nvlist_t *vdev = fnvlist_alloc();
-	char *endpoint, *region, *creds;
+	char *endpoint, *region, *profile;
 	fnvlist_add_string(vdev, ZPOOL_CONFIG_PATH, arg);
 	fnvlist_add_string(vdev, ZPOOL_CONFIG_TYPE, VDEV_TYPE_OBJSTORE);
 
@@ -288,23 +288,9 @@ make_objstore_vdev(nvlist_t *props, const char *arg)
 	    region);
 
 	if ((nvlist_lookup_string(props,
-	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS), &creds)) != 0) {
-		fprintf(stderr, gettext("No credentials location provided for "
-		    "objstore vdev %s\n"), arg);
-		fnvlist_free(vdev);
-		return (NULL);
+	    zpool_prop_to_name(ZPOOL_PROP_OBJ_CRED_PROFILE), &profile)) == 0) {
+		fnvlist_add_string(vdev, ZPOOL_CONFIG_CRED_PROFILE, profile);
 	}
-	fnvlist_add_string(vdev, zpool_prop_to_name(ZPOOL_PROP_OBJ_CREDENTIALS),
-	    creds);
-
-	if ((nvlist_lookup_string(props, ZPOOL_CONFIG_OBJSTORE_CREDENTIALS,
-	    &creds)) != 0) {
-		fprintf(stderr, gettext("No credentials provided for "
-		    "objstore vdev %s\n"), arg);
-		fnvlist_free(vdev);
-		return (NULL);
-	}
-	fnvlist_add_string(vdev, ZPOOL_CONFIG_OBJSTORE_CREDENTIALS, creds);
 
 	return (vdev);
 }

--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -335,8 +335,6 @@ _LIBZFS_H int zpool_props_refresh(zpool_handle_t *);
 
 _LIBZFS_H const char *zpool_prop_to_name(zpool_prop_t);
 _LIBZFS_H const char *zpool_prop_values(zpool_prop_t);
-_LIBZFS_H int zpool_get_objstore_credentials(libzfs_handle_t *, char *,
-    char **);
 
 /*
  * Pool health statistics.

--- a/include/libzutil.h
+++ b/include/libzutil.h
@@ -68,7 +68,6 @@ typedef struct importargs {
 	boolean_t can_be_active; /* can the pool be active?		*/
 	boolean_t scan;		/* prefer scanning to libblkid cache    */
 	nvlist_t *policy;	/* load policy (max txg, rewind, etc.)	*/
-	int (*handle_creds)(void *, char *, char **);
 	nvlist_t *props;
 } importargs_t;
 

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -249,7 +249,7 @@ typedef enum {
 	ZPOOL_PROP_COMPATIBILITY,
 	ZPOOL_PROP_OBJ_ENDPOINT,
 	ZPOOL_PROP_OBJ_REGION,
-	ZPOOL_PROP_OBJ_CREDENTIALS,
+	ZPOOL_PROP_OBJ_CRED_PROFILE,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -638,7 +638,7 @@ typedef struct zpool_load_policy {
 #define	ZPOOL_CONFIG_VDEV_STATS		"vdev_stats"	/* not stored on disk */
 #define	ZPOOL_CONFIG_INDIRECT_SIZE	"indirect_size"	/* not stored on disk */
 /* not stored on disk */
-#define	ZPOOL_CONFIG_OBJSTORE_CREDENTIALS "objstore_credentials"
+#define	ZPOOL_CONFIG_CRED_PROFILE	"credentials_profile"
 
 /* container nvlist of extended stats */
 #define	ZPOOL_CONFIG_VDEV_STATS_EX	"vdev_stats_ex"

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -64,7 +64,6 @@
 #define	MIN_PASSPHRASE_LEN 8
 #define	MAX_PASSPHRASE_LEN 512
 #define	MAX_KEY_PROMPT_ATTEMPTS 3
-#define	MAX_INI_FILE_LEN 1024
 
 static int caught_interrupt;
 
@@ -112,9 +111,6 @@ zfs_prop_parse_keylocation(libzfs_handle_t *restrict hdl, const char *str,
 
 	if (strcmp("prompt", str) == 0) {
 		*locp = ZFS_KEYLOCATION_PROMPT;
-		return (0);
-	} else if (strcmp("environment", str) == 0) {
-		*locp = ZFS_KEYLOCATION_ENVIRONMENT;
 		return (0);
 	}
 
@@ -427,35 +423,7 @@ get_key_material_raw(FILE *fd, zfs_keyformat_t keyformat,
 	*len_out = 0;
 
 	/* read the key material */
-	if (keyformat == ZFS_KEYFORMAT_RAW || keyformat == ZFS_KEYFORMAT_INI) {
-		size_t n;
-		size_t buf_len = (keyformat == ZFS_KEYFORMAT_INI)
-		    ? MAX_INI_FILE_LEN : WRAPPING_KEY_LEN + 1;
-
-		/*
-		 * Raw keys may have newline characters in them and so can't
-		 * use getline(). Here we attempt to read 33 bytes so that we
-		 * can properly check the key length (the file should only have
-		 * 32 bytes). For INI files, we read MAX_INI_FILE_LEN bytes.
-		 */
-		*buf = malloc(buf_len * sizeof (uint8_t));
-		if (*buf == NULL) {
-			ret = ENOMEM;
-			goto out;
-		}
-
-		n = fread(*buf, 1, buf_len, fd);
-		if (n == 0 || ferror(fd)) {
-			/* size errors are handled by the calling function */
-			free(*buf);
-			*buf = NULL;
-			ret = errno;
-			errno = 0;
-			goto out;
-		}
-
-		*len_out = n;
-	} else {
+	if (keyformat != ZFS_KEYFORMAT_RAW) {
 		ssize_t bytes;
 
 		bytes = getline((char **)buf, &buflen, fd);
@@ -472,6 +440,32 @@ get_key_material_raw(FILE *fd, zfs_keyformat_t keyformat,
 		}
 
 		*len_out = bytes;
+	} else {
+		size_t n;
+
+		/*
+		 * Raw keys may have newline characters in them and so can't
+		 * use getline(). Here we attempt to read 33 bytes so that we
+		 * can properly check the key length (the file should only have
+		 * 32 bytes).
+		 */
+		*buf = malloc((WRAPPING_KEY_LEN + 1) * sizeof (uint8_t));
+		if (*buf == NULL) {
+			ret = ENOMEM;
+			goto out;
+		}
+
+		n = fread(*buf, 1, WRAPPING_KEY_LEN + 1, fd);
+		if (n == 0 || ferror(fd)) {
+			/* size errors are handled by the calling function */
+			free(*buf);
+			*buf = NULL;
+			ret = errno;
+			errno = 0;
+			goto out;
+		}
+
+		*len_out = n;
 	}
 out:
 	return (ret);
@@ -681,7 +675,7 @@ end:
  * to B_TRUE if the user is providing the key material interactively, allowing
  * for re-entry attempts.
  */
-int
+static int
 get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
     zfs_keyformat_t keyformat, char *keylocation, const char *fsname,
     uint8_t **km_out, size_t *kmlen_out, boolean_t *can_retry_out)
@@ -739,9 +733,6 @@ get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
 		}
 
 		break;
-	case ZFS_KEYLOCATION_ENVIRONMENT:
-		// TODO
-		break;
 	default:
 		ret = EINVAL;
 		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
@@ -749,7 +740,6 @@ get_key_material(libzfs_handle_t *hdl, boolean_t do_verify, boolean_t newkey,
 		goto error;
 	}
 
-	/* TODO: Ideally we wouldn't do this for the objstore case */
 	if ((ret = validate_key(hdl, keyformat, (const char *)km, kmlen)) != 0)
 		goto error;
 

--- a/lib/libzfs/libzfs_impl.h
+++ b/lib/libzfs/libzfs_impl.h
@@ -259,11 +259,6 @@ extern int find_shares_object(differ_info_t *di);
 extern void libzfs_set_pipe_max(int infd);
 extern void zfs_commit_proto(zfs_share_proto_t *);
 
-extern int get_key_material(libzfs_handle_t *hdl, boolean_t do_verify,
-    boolean_t newkey, zfs_keyformat_t keyformat, char *keylocation,
-    const char *fsname, uint8_t **km_out, size_t *kmlen_out,
-    boolean_t *can_retry_out);
-
 #ifdef	__cplusplus
 }
 #endif

--- a/lib/libzfs/libzfs_pool.c
+++ b/lib/libzfs/libzfs_pool.c
@@ -4948,20 +4948,3 @@ zpool_load_compat(const char *compat, boolean_t *features, char *report,
 		strlcpy(report, gettext("compatibility set ok"), rlen);
 	return (ZPOOL_COMPATIBILITY_OK);
 }
-
-int
-zpool_get_objstore_credentials(libzfs_handle_t *hdl,
-    char *credloc, char **creds)
-{
-	size_t creds_len;
-	int err = get_key_material(hdl, B_FALSE, B_FALSE,
-	    ZFS_KEYFORMAT_PASSPHRASE, credloc, NULL, (uint8_t **)creds,
-	    &creds_len, NULL);
-	if (err != 0) {
-		(void) zpool_standard_error_fmt(hdl, EINVAL,
-		    dgettext(TEXT_DOMAIN, "error getting pool credentials"));
-		return (err);
-	}
-
-	return (err);
-}

--- a/module/zcommon/zpool_prop.c
+++ b/module/zcommon/zpool_prop.c
@@ -79,9 +79,9 @@ zpool_prop_init(void)
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "<uri>", "OBJ_ENDPOINT");
 	zprop_register_string(ZPOOL_PROP_OBJ_REGION, "object-region", NULL,
 	    PROP_DEFAULT, ZFS_TYPE_POOL, "<uri>", "OBJ_REGION");
-	zprop_register_string(ZPOOL_PROP_OBJ_CREDENTIALS,
-	    "object-credentials-location", NULL, PROP_DEFAULT, ZFS_TYPE_POOL,
-	    "<uri>", "OBJ_CREDENTIALS");
+	zprop_register_string(ZPOOL_PROP_OBJ_CRED_PROFILE,
+	    "object-credentials-profile", NULL, PROP_DEFAULT, ZFS_TYPE_POOL,
+	    "<uri>", "OBJ_CRED_PROFILE");
 
 	/* readonly number properties */
 	zprop_register_number(ZPOOL_PROP_SIZE, "size", 0, PROP_READONLY,

--- a/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
+++ b/tests/zfs-tests/tests/functional/cli_root/zpool_get/zpool_get.cfg
@@ -60,7 +60,7 @@ typeset -a properties=(
     "compatibility"
     "object-endpoint"
     "object-region"
-    "object-credentials-location"
+    "object-credentials-profile"
     "feature@async_destroy"
     "feature@empty_bpobj"
     "feature@lz4_compress"


### PR DESCRIPTION
The zfs-object-agent now deals with credentials the AWS way (via ~/.aws/credentials and ~/.aws/config). The ZFS kernel module no longer needs to concern itself with reading the credentials file. This change removes the `object-credentials-location` parameter.

To support using different credentials for different zpools, an optional `object-credentials-profile` parameter is being added. If it is not specified, a "default" profile is assumed.

Testing:
Setup two profiles:

1. test-cred : for accessing cloudburst-data-2 with an ID and secret key
2. test-ip: for accessing dcoa-gparton-manoj-object-internal-variant using instance profile based credentials.

```
root@ip-10-110-137-138:~# echo $AWS_SECRET_ACCESS_KEY

root@ip-10-110-137-138:~# echo $AWS_ACCESS_KEY_ID

root@ip-10-110-137-138:~# cat ~/.aws/credentials
[test-cred]
aws_secret_access_key = jSb8cNLeSntTszxb82cNrhhtvTjKPtNWKyrzNOO8
aws_access_key_id = AKIAUW6JOZCF4YQNTF4P
root@ip-10-110-137-138:~# cat ~/.aws/config 
[profile test-ip]
credential_source = Ec2InstanceMetadata
root@ip-10-110-137-138:~# 
```
Create pools:
```
delphix@ip-10-110-137-138:~$ sudo zpool create -o cachefile=none -o object-endpoint=https://s3-us-west-2.amazonaws.com  -o object-region=us-west-2  -o object-credentials-profile=test-ip test-pool-ip-123456 s3 dcoa-gparton-manoj-object-internal-variant
delphix@ip-10-110-137-138:~$ sudo zpool create -o cachefile=none -o object-endpoint=https://s3-us-west-2.amazonaws.com  -o object-region=us-west-2 -o object-credentials-profile=test-cred test-pool-cred-123456 s3 cloudburst-data-2
delphix@ip-10-110-137-138:~$ zpool status
  pool: rpool
 state: ONLINE
status: The pool is formatted using a legacy on-disk format.  The pool can
        still be used, but some features are unavailable.
action: Upgrade the pool using 'zpool upgrade'.  Once this is done, the
        pool will no longer be accessible on software that does not support
        feature flags.
config:

        NAME         STATE     READ WRITE CKSUM
        rpool        ONLINE       0     0     0
          nvme0n1p1  ONLINE       0     0     0

errors: No known data errors

  pool: test-pool-cred-123456
 state: ONLINE
config:

        NAME                   STATE     READ WRITE CKSUM
        test-pool-cred-123456  ONLINE       0     0     0
          cloudburst-data-2    ONLINE       0     0     0

errors: No known data errors

  pool: test-pool-ip-123456
 state: ONLINE
config:

        NAME                                          STATE     READ WRITE CKSUM
        test-pool-ip-123456                           ONLINE       0     0     0
          dcoa-gparton-manoj-object-internal-variant  ONLINE       0     0     0

errors: No known data errors
delphix@ip-10-110-137-138:~$ 
```
export/import
```
delphix@ip-10-110-137-138:~$ sudo zpool export test-pool-cred-123456
delphix@ip-10-110-137-138:~$ sudo zpool export test-pool-ip-123456
delphix@ip-10-110-137-138:~$ sudo zpool import -d cloudburst-data-2 -o object-endpoint="https://s3-us-west-2.amazonaws.com" -o object-region="us-west-2" test-pool-cred-123456
^C
delphix@ip-10-110-137-138:~$ sudo zpool import -d cloudburst-data-2 -o object-endpoint="https://s3-us-west-2.amazonaws.com" -o object-region="us-west-2" -o object-credentials-profile=test-cred  test-pool-cred-123456
delphix@ip-10-110-137-138:~$ sudo zpool import -d dcoa-gparton-manoj-object-internal-variant -o object-endpoint="https://s3-us-west-2.amazonaws.com" -o object-region="us-west-2" -o object-credentials-profile=test-ip test-pool-ip-123456
delphix@ip-10-110-137-138:~$ 
```
zdb
```
delphix@ip-10-110-137-138:~$ sudo zdb -e -a https://s3-us-west-2.amazonaws.com -g us-west-2 -B cloudburst-data-2 -f test-cred test-pool-cred-123456

Configuration for import:
        vdev_children: 1
        version: 5000
        pool_guid: 13022540920147607395
        name: 'test-pool-cred-123456'
        state: 1
        vdev_tree:
            type: 'root'
            id: 0
            guid: 13022540920147607395
            children[0]:
                type: 'object_store'
                id: 0
                guid: 6454426480365290671
                object-endpoint: 'https://s3-us-west-2.amazonaws.com'
                object-region: 'us-west-2'
                object-credentials-profile: 'test-cred'
                metaslab_array: 68
                metaslab_shift: 59
                ashift: 9
                asize: 1152921504606584832
                is_log: 0
                create_txg: 4
                path: 'cloudburst-data-2'
        load-policy:
            load-request-txg: 18446744073709551615
            load-rewind-policy: 2
<snip>
vdev_object_store.c:888:agent_reader(): got read done req=23 datalen=1024
ZFS_DBGMSG(zdb) END
delphix@ip-10-110-137-138:~$ 
delphix@ip-10-110-137-138:~$ sudo zdb -e -a https://s3-us-west-2.amazonaws.com -g us-west-2 -B dcoa-gparton-manoj-object-internal-variant -f test-ip test-pool-ip-123456

Configuration for import:
        vdev_children: 1
        version: 5000
        pool_guid: 1209979112375486256
        name: 'test-pool-ip-123456'
        state: 1
        vdev_tree:
            type: 'root'
            id: 0
            guid: 1209979112375486256
            children[0]:
                type: 'object_store'
                id: 0
                guid: 7436545996208652391
                object-endpoint: 'https://s3-us-west-2.amazonaws.com'
                object-region: 'us-west-2'
                object-credentials-profile: 'test-ip'
                metaslab_array: 65
                metaslab_shift: 59
                ashift: 9
                asize: 1152921504606584832
                is_log: 0
                create_txg: 4
                path: 'dcoa-gparton-manoj-object-internal-variant'
        load-policy:
            load-request-txg: 18446744073709551615
            load-rewind-policy: 2
<snip>
vdev_object_store.c:888:agent_reader(): got read done req=2 datalen=2048
ZFS_DBGMSG(zdb) END
delphix@ip-10-110-137-138:~$ 
```
ztest
```
delphix@ip-10-110-137-138:~$ sudo ztest -b dcoa-gparton-manoj-object-internal-variant -z test-ip -T 5 -G -V
7 datasets, 23 threads, object-store https://s3-us-west-2.amazonaws.com, 5 seconds...

verifying concrete vdev 0, metaslab 0 of 1 ...
verifying concrete vdev 0, metaslab 0 of 1 ...
Pass   1,  SIGKILL,   0 ENOSPC,  0.0% of  512P used,  13% done,       4s to go
verifying concrete vdev 0, metaslab 0 of 1 ...
1 killed, 0 completed, 100% kill rate
delphix@ip-10-110-137-138:~$ sudo ztest -b cloudburst-data-2 -z test-cred -T 5 -G -V
7 datasets, 23 threads, object-store https://s3-us-west-2.amazonaws.com, 5 seconds...

verifying concrete vdev 0, metaslab 0 of 1 ...
verifying concrete vdev 0, metaslab 0 of 1 ...
Pass   1,  SIGKILL,   0 ENOSPC,  0.0% of  512P used,  18% done,       4s to go
verifying concrete vdev 0, metaslab 0 of 1 ...
1 killed, 0 completed, 100% kill rate
delphix@ip-10-110-137-138:~$ 
```
zoa_test:
```
delphix@ip-10-110-137-138:~$ zoa_test -p test-ip -b dcoa-gparton-manoj-object-internal-variant list_pools
endpoint: https://s3-us-west-2.amazonaws.com, region: us-west-2, bucket: dcoa-gparton-manoj-object-internal-variant profile: test-ip access_id: None, secret_key: None
2021-07-09 01:15:55 +00:00 zfs/01209979112375486256/                    test-pool-ip-123456  ip-10-110-137-138
2021-07-08 05:33:43 +00:00 zfs/03088466662308190585/                    test-pool-ip-1234    ip-10-110-137-138
2021-07-09 01:21:09 +00:00 zfs/03437328783378527670/                    ztest                ip-10-110-137-138
delphix@ip-10-110-137-138:~$ 
delphix@ip-10-110-137-138:~$ zoa_test -p test-cred -b cloudburst-data-2 list_pools 
endpoint: https://s3-us-west-2.amazonaws.com, region: us-west-2, bucket: cloudburst-data-2 profile: test-cred access_id: None, secret_key: None
2021-07-07 23:18:34 +00:00 zfs/00280743538699085892/                    test-pool-cred-123   ip-10-110-137-138
2021-07-08 04:26:12 +00:00 zfs/00732457035462752381/                    ztest                ip-10-110-137-138
<snip>
2021-07-06 15:20:45 +00:00 zfs/18027686271298092803/                    perfpool             ip-10-110-252-99
2021-07-07 23:01:15 +00:00 mmp/zfs/06545242163195930527/                (pool inside an alt AWS_PREFIX)
2021-07-07 19:33:38 +00:00 mmp/zfs/17446583821794146820/                (pool inside an alt AWS_PREFIX)
didn't find super object for mmp/zfs/agents/
didn't find super object for mmp2/zfs/agents/
delphix@ip-10-110-137-138:~$ 
```

Follow-up work needed:
- We still have rough edges around error handling. For instance, if the credentials don't work, the kernel sees that `vdev_state != VDEV_STATE_HEALTHY` and panics.
- The pool property includes the profile used to create the pool. When trying to import the pool, if it was originally created with a profile that no longer exists, import fails. We need to be smarter and use the profile specified on the command line.