### PR TITLE
Fix build failures

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -21,7 +21,7 @@ SHELLCHECKDIRS += zed
 endif
 
 if BUILD_RUST
-SUBDIRS += zfs_object_agent
+SUBDIRS += zfs_object_agent zfs_object_agent/scripts
 endif
 
 PHONY = cppcheck

--- a/cmd/zfs_object_agent/.gitignore
+++ b/cmd/zfs_object_agent/.gitignore
@@ -1,1 +1,3 @@
 /target
+zfs_object_agent
+zoa_test

--- a/cmd/zfs_object_agent/Makefile.am
+++ b/cmd/zfs_object_agent/Makefile.am
@@ -1,10 +1,8 @@
 sbin_PROGRAMS = zfs_object_agent zoa_test
 
-bin_SCRIPTS = scripts/zoa_chaos_monkey
+zfs_object_agent_SOURCES = $(wildcard server/src/*.rs src/*.rs Cargo.lock Cargo.toml server/Cargo.toml)
 
-zfs_object_agent_SOURCES = $(wildcard server/src/*.rs src/*.rs)
-
-zoa_test_SOURCES = $(wildcard client/src/*.rs src/*.rs)
+zoa_test_SOURCES = $(wildcard client/src/*.rs src/*.rs Cargo.lock Cargo.toml client/Cargo.toml)
 
 RUSTFLAGS = \
 	-L $(abs_top_builddir)/lib/libzfs/.libs \

--- a/cmd/zfs_object_agent/scripts/Makefile.am
+++ b/cmd/zfs_object_agent/scripts/Makefile.am
@@ -1,0 +1,1 @@
+dist_bin_SCRIPTS = zoa_chaos_monkey

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,7 @@ AC_CONFIG_FILES([
 	cmd/zfs_file/Makefile
 	cmd/zfs_ids_to_path/Makefile
 	cmd/zfs_object_agent/Makefile
+	cmd/zfs_object_agent/scripts/Makefile
 	cmd/zgenhostid/Makefile
 	cmd/zhack/Makefile
 	cmd/zinject/Makefile

--- a/rpm/generic/zfs.spec.in
+++ b/rpm/generic/zfs.spec.in
@@ -476,6 +476,8 @@ systemctl --system daemon-reload >/dev/null || true
 %{_bindir}/raidz_test
 %{_sbindir}/zgenhostid
 %{_bindir}/zvol_wait
+# Optional zfs_object_agent script
+%{_bindir}/zoa_chaos_monkey
 # Optional Python 2/3 scripts
 %{_bindir}/arc_summary
 %{_bindir}/arcstat


### PR DESCRIPTION
With this change, automated builds succeed. This changes fixes the following build failures:

```
Making all in zfs_object_agent
make[5]: *** No rule to make target 'scripts/zoa_chaos_monkey', needed by 'all-am'.  Stop.
```
```
Making all in zfs_object_agent
error: could not find `Cargo.toml` in `/tmp/zfs-build-delphix-FQxEFmaA/BUILD/zfs-2.1.99/cmd/zfs_object_agent` or any parent directory
error: could not find `Cargo.toml` in `/tmp/zfs-build-delphix-FQxEFmaA/BUILD/zfs-2.1.99/cmd/zfs_object_agent` or any parent directory
Makefile:945: recipe for target 'zoa_test' failed
make[5]: *** [zoa_test] Error 101
```

```
    Installed (but unpackaged) file(s) found:
   /usr/bin/zoa_chaos_monkey
Makefile:1651: recipe for target 'rpm-common' failed
make[1]: *** [rpm-common] Error 1
```

```
  make codecheck
  shell: /bin/bash -e {0}
cmd/zfs_object_agent/zfs_object_agent
cmd/zfs_object_agent/zoa_test
make: *** [vcscheck] Error 1
Makefile:1545: recipe for target 'vcscheck' failed
Error: Process completed with exit code 2.
```
